### PR TITLE
[BNK-135] Fix : 소셜 로그인 시 자산연동 500에러 해결 및 거래내역 프론트연동 완료

### DIFF
--- a/src/main/java/com/banklab/security/account/domain/CustomUser.java
+++ b/src/main/java/com/banklab/security/account/domain/CustomUser.java
@@ -1,5 +1,6 @@
 package com.banklab.security.account.domain;
 
+import com.banklab.oauth.domain.OAuthProvider;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -20,7 +21,7 @@ public class CustomUser extends User {
     // MemberVO를 받는 생성자 - 실제로 주로 사용
     public CustomUser(MemberVO vo) {
         super(vo.getEmail(),           // 사용자 ID
-                vo.getPassword(),           // 암호화된 비밀번호
+                (vo.getProvider() == OAuthProvider.LOCAL) ? vo.getPassword() : "SOCIAL_USER",
                 vo.getAuthList());          // 권한 목록 (List<AuthVO>)
 
         this.member = vo;                 // 추가 사용자 정보 저장

--- a/src/main/resources/com/banklab/member/mapper/MemberMapper.xml
+++ b/src/main/resources/com/banklab/member/mapper/MemberMapper.xml
@@ -54,7 +54,7 @@
         SELECT * FROM member WHERE email = #{email}
     </select>
     <select id="findByProviderAndProviderId" resultMap="memberMap">
-        SELECT email, password, name, phone, gender, birth_date, reg_date, update_date, auth
+        SELECT m.member_id, email, password, name, phone, gender, birth_date, reg_date, update_date, auth
         FROM
             member m
                 LEFT OUTER JOIN member_auth a


### PR DESCRIPTION
### [BNK-135] Fix : 소셜 로그인 시 자산연동 500에러 해결 및 거래내역 프론트연동 완료

## 개요

- 소셜 로그인 시 자산연동 에러 해결
- URL 라우팅 시 id 전달 필요로 AccountDTO 수정

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 코드에 영향 없는 수정
- [ ] 문서 수정
- [ ] 테스트 추가/리팩토링
- [ ] 빌드/패키지 관련
- [ ] 파일/폴더명 수정
- [ ] 파일 삭제

## PR Checklist

- [x] 1. 커밋 메시지 컨벤션을 지켰나요?
- [x] 2. 기능 테스트를 완료했나요?
- [ ] 3-1. main 브랜치로 머지 요청했나요?
- [ ] 3-2. Develop 브랜치로 머지 요청했나요?

## 테스트 결과 (캡쳐이미지)


[BNK-135]: https://banklab00.atlassian.net/browse/BNK-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ