### PR TITLE
[BNK-109] 유형검사에 따른 결과 제한 및 상품 추천 고도화

### DIFF
--- a/src/main/java/com/banklab/product/handler/ProductTypeHandler.java
+++ b/src/main/java/com/banklab/product/handler/ProductTypeHandler.java
@@ -1,0 +1,45 @@
+package com.banklab.product.handler;
+
+import com.banklab.product.domain.ProductType;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class ProductTypeHandler extends BaseTypeHandler<ProductType> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, ProductType parameter, JdbcType jdbcType) throws SQLException {
+        ps.setString(i, parameter.name());
+    }
+
+    @Override
+    public ProductType getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        String value = rs.getString(columnName);
+        if (value != null) {
+            return ProductType.valueOf(value);
+        }
+        return null;
+    }
+
+    @Override
+    public ProductType getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        String value = rs.getString(columnIndex);
+        if (value != null) {
+            return ProductType.valueOf(value);
+        }
+        return null;
+    }
+
+    @Override
+    public ProductType getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String value = cs.getString(columnIndex);
+        if (value != null) {
+            return ProductType.valueOf(value);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/banklab/risk/handler/RiskLevelHandler.java
+++ b/src/main/java/com/banklab/risk/handler/RiskLevelHandler.java
@@ -1,0 +1,49 @@
+package com.banklab.risk.handler;
+
+import com.banklab.risk.domain.RiskLevel;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class RiskLevelHandler extends BaseTypeHandler<RiskLevel> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, RiskLevel parameter, JdbcType jdbcType) throws SQLException {
+        // RiskLevel Enum을 DB에 저장할 때 String 값으로 저장
+        ps.setString(i, parameter.name());
+    }
+
+    @Override
+    public RiskLevel getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        // DB에서 가져온 값을 Enum으로 변환
+        String value = rs.getString(columnName);
+        if (value != null) {
+            return RiskLevel.valueOf(value);
+        }
+        return null;
+    }
+
+    @Override
+    public RiskLevel getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        // DB에서 가져온 값을 Enum으로 변환
+        String value = rs.getString(columnIndex);
+        if (value != null) {
+            return RiskLevel.valueOf(value);
+        }
+        return null;
+    }
+
+    @Override
+    public RiskLevel getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        // CallableStatement에서 값을 가져올 때 처리
+        String value = cs.getString(columnIndex);
+        if (value != null) {
+            return RiskLevel.valueOf(value);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/banklab/typetest/controller/TypeTestController.java
+++ b/src/main/java/com/banklab/typetest/controller/TypeTestController.java
@@ -39,35 +39,35 @@ public class TypeTestController {
     }
 
     /**
-     * 사용자가 유형검사를 제출합니다
+     * 사용자가 유형검사를 제출합니다 (OK만 반환)
      * @param request 토큰 추출을 위한 request
      * @param payload 질문 답변
-     * @return 사용자의 투자 유형과 추천 상품이 반환됩니다.
+     * @return OK 메시지
      */
-    @PostMapping("")
-    public ResponseEntity<TypeTestResultDTO> submitAnswers(HttpServletRequest request, @RequestBody Map<String, Object> payload) {
+    @PostMapping("/submit")
+    public ResponseEntity<Map<String, String>> submitAnswers(HttpServletRequest request, @RequestBody Map<String, Object> payload) {
         String token = JwtTokenUtil.extractToken(request);
         Long memberId = jwtProcessor.getMemberId(token);
         if (memberId == null) {
-            return ResponseEntity.badRequest().body(TypeTestResultDTO.builder().message("유효하지 않은 토큰입니다.").build());
+            return ResponseEntity.badRequest().body(Map.of("message", "유효하지 않은 토큰입니다."));
         }
-        return ResponseEntity.ok(typeTestService.submitAnswersWithMemberId(payload, memberId));
+        typeTestService.submitAnswersWithMemberId(payload, memberId);
+        return ResponseEntity.ok(Map.of("message", "OK"));
     }
 
     /**
-     * 사용자 투자 유형 조회API
+     * 사용자 투자 유형 결과 및 추천상품 4개 반환
      * @param request 토큰 추출을 위한 request
-     * @return 검사결과가 있는 경우, 사용자 투자유형과 추천 상품이 반환됩니다.
-     * @return 검사결과가 없는 경우, 투자유형 검사로 유도합니다.
+     * @return 검사결과가 있는 경우, 사용자 투자유형과 추천 상품 4개 반환
+     * @return 검사결과가 없는 경우, 검사 유도 메시지 반환
      */
     @GetMapping("/result")
     public ResponseEntity<TypeTestResultDTO> getTestResultByToken(HttpServletRequest request) {
         String token = JwtTokenUtil.extractToken(request);
         Long memberId = jwtProcessor.getMemberId(token);
         if (memberId == null) {
-            System.out.println("member Id 가 null 입니다.");
+            return ResponseEntity.badRequest().body(TypeTestResultDTO.builder().message("유효하지 않은 토큰입니다.").build());
         }
-        // 서비스에서 결과가 없으면 안내 메시지 반환
         TypeTestResultDTO result = typeTestService.getTestResultByUserId(memberId);
         if (result == null || result.getInvestmentTypeId() == null) {
             return ResponseEntity.ok(TypeTestResultDTO.builder().message("검사 결과가 없습니다. 먼저 검사를 진행하세요.").build());
@@ -75,4 +75,22 @@ public class TypeTestController {
         return ResponseEntity.ok(result);
     }
 
+    /**
+     * 사용자 투자유형에 따른 전체 상품(위험도별 매핑) 반환
+     * @param request 토큰 추출을 위한 request
+     * @return 투자유형, 위험도별 전체 상품 리스트
+     */
+    @GetMapping("/result/all")
+    public ResponseEntity<TypeTestResultDTO> getAllProductsByType(HttpServletRequest request) {
+        String token = JwtTokenUtil.extractToken(request);
+        Long memberId = jwtProcessor.getMemberId(token);
+        if (memberId == null) {
+            return ResponseEntity.badRequest().body(TypeTestResultDTO.builder().message("유효하지 않은 토큰입니다.").build());
+        }
+        TypeTestResultDTO result = typeTestService.getAllProductsByType(memberId);
+        if (result == null || result.getInvestmentTypeId() == null) {
+            return ResponseEntity.ok(TypeTestResultDTO.builder().message("검사 결과가 없습니다. 먼저 검사를 진행하세요.").build());
+        }
+        return ResponseEntity.ok(result);
+    }
 }

--- a/src/main/java/com/banklab/typetest/domain/ChoiceType.java
+++ b/src/main/java/com/banklab/typetest/domain/ChoiceType.java
@@ -1,5 +1,0 @@
-package com.banklab.typetest.domain;
-
-public enum ChoiceType {
-    A, B;
-}

--- a/src/main/java/com/banklab/typetest/domain/Question.java
+++ b/src/main/java/com/banklab/typetest/domain/Question.java
@@ -1,5 +1,6 @@
 package com.banklab.typetest.domain;
 
+import com.banklab.typetest.domain.enums.QuestionType;
 import lombok.Data;
 
 @Data
@@ -8,4 +9,6 @@ public class Question {
     private String questionText;
     private String choiceAText;
     private String choiceBText;
+    private QuestionType questionType;  // 질문 유형 추가
+    private Boolean isBlocking;         // 제한 여부
 }

--- a/src/main/java/com/banklab/typetest/domain/Question.java
+++ b/src/main/java/com/banklab/typetest/domain/Question.java
@@ -9,6 +9,6 @@ public class Question {
     private String questionText;
     private String choiceAText;
     private String choiceBText;
-    private QuestionType questionType;  // 질문 유형 추가
+    private QuestionType questionType;  // 질문 유형
     private Boolean isBlocking;         // 제한 여부
 }

--- a/src/main/java/com/banklab/typetest/domain/QuestionChoiceScore.java
+++ b/src/main/java/com/banklab/typetest/domain/QuestionChoiceScore.java
@@ -1,5 +1,6 @@
 package com.banklab.typetest.domain;
 
+import com.banklab.typetest.domain.enums.ChoiceType;
 import lombok.Data;
 
 @Data

--- a/src/main/java/com/banklab/typetest/domain/UserInvestmentConstraints.java
+++ b/src/main/java/com/banklab/typetest/domain/UserInvestmentConstraints.java
@@ -1,0 +1,18 @@
+package com.banklab.typetest.domain;
+
+import com.banklab.typetest.domain.enums.ConstraintType;
+import lombok.Data;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInvestmentConstraints {
+    private Long id;
+    private Long userId;
+    private ConstraintType constraintType;
+    private Boolean isActive;
+}

--- a/src/main/java/com/banklab/typetest/domain/UserInvestmentConstraints.java
+++ b/src/main/java/com/banklab/typetest/domain/UserInvestmentConstraints.java
@@ -13,6 +13,6 @@ import lombok.AllArgsConstructor;
 public class UserInvestmentConstraints {
     private Long id;
     private Long userId;
-    private ConstraintType constraintType;
+    private ConstraintType constraintType; //제약조건
     private Boolean isActive;
 }

--- a/src/main/java/com/banklab/typetest/domain/UserInvestmentProfile.java
+++ b/src/main/java/com/banklab/typetest/domain/UserInvestmentProfile.java
@@ -12,12 +12,11 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public class UserInvestmentProfile {
     private Long id;
-    private Long userId;
-    private AmountRange availableAmountRange;
-    private ReturnRange targetReturnRange;
-    private PeriodRange investmentPeriodRange;
-    private RiskRange lossToleranceRange;
-    private InvestmentStyle investmentStyle;
-    private Priority priority;
+    private Long userId; // 사용자 ID
+    private AmountRange availableAmountRange; // 사용자가 투자 가능한 금액 범위
+    private ReturnRange targetReturnRange; // 사용자가 목표로 하는 수익률 범위
+    private PeriodRange investmentPeriodRange; // 사용자가 희망하는 투자 기간 범위
+    private RiskRange lossToleranceRange; // 사용자가 감내할 수 있는 손실 허용 범위(리스크)
+    private InvestmentStyle investmentStyle; // 사용자의 투자 성향(예: 일시금, 분할납부 등)
+    private Priority priority; // 투자 시 우선순위(예: 안정성, 수익 등)
 }
-

--- a/src/main/java/com/banklab/typetest/domain/UserInvestmentProfile.java
+++ b/src/main/java/com/banklab/typetest/domain/UserInvestmentProfile.java
@@ -1,0 +1,23 @@
+package com.banklab.typetest.domain;
+
+import com.banklab.typetest.domain.enums.*;
+import lombok.Data;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInvestmentProfile {
+    private Long id;
+    private Long userId;
+    private AmountRange availableAmountRange;
+    private ReturnRange targetReturnRange;
+    private PeriodRange investmentPeriodRange;
+    private RiskRange lossToleranceRange;
+    private InvestmentStyle investmentStyle;
+    private Priority priority;
+}
+

--- a/src/main/java/com/banklab/typetest/domain/UserInvestmentType.java
+++ b/src/main/java/com/banklab/typetest/domain/UserInvestmentType.java
@@ -8,6 +8,6 @@ import java.time.LocalDate;
 public class UserInvestmentType {
     private Long id;
     private Long userId;
-    private Long investmentTypeId;
-    private LocalDate evaluationDate;
+    private Long investmentTypeId; //투자 유형
+    private LocalDate evaluationDate; //평가일
 }

--- a/src/main/java/com/banklab/typetest/domain/enums/AmountRange.java
+++ b/src/main/java/com/banklab/typetest/domain/enums/AmountRange.java
@@ -1,6 +1,6 @@
 package com.banklab.typetest.domain.enums;
 
-// Enum 정의들
+
 public enum AmountRange {
     UNDER_500, OVER_500
 }

--- a/src/main/java/com/banklab/typetest/domain/enums/AmountRange.java
+++ b/src/main/java/com/banklab/typetest/domain/enums/AmountRange.java
@@ -1,0 +1,6 @@
+package com.banklab.typetest.domain.enums;
+
+// Enum 정의들
+public enum AmountRange {
+    UNDER_500, OVER_500
+}

--- a/src/main/java/com/banklab/typetest/domain/enums/ChoiceType.java
+++ b/src/main/java/com/banklab/typetest/domain/enums/ChoiceType.java
@@ -1,0 +1,5 @@
+package com.banklab.typetest.domain.enums;
+
+public enum ChoiceType {
+    A, B;
+}

--- a/src/main/java/com/banklab/typetest/domain/enums/ConstraintType.java
+++ b/src/main/java/com/banklab/typetest/domain/enums/ConstraintType.java
@@ -1,6 +1,5 @@
 package com.banklab.typetest.domain.enums;
 
-// 제약조건 타입 enum
 public enum ConstraintType {
     PRINCIPAL_GUARANTEE,     // 원금보장 필수
     HIGH_RISK_FORBIDDEN,     // 고위험 상품 금지

--- a/src/main/java/com/banklab/typetest/domain/enums/ConstraintType.java
+++ b/src/main/java/com/banklab/typetest/domain/enums/ConstraintType.java
@@ -1,0 +1,8 @@
+package com.banklab.typetest.domain.enums;
+
+// 제약조건 타입 enum
+public enum ConstraintType {
+    PRINCIPAL_GUARANTEE,     // 원금보장 필수
+    HIGH_RISK_FORBIDDEN,     // 고위험 상품 금지
+    LIQUIDITY_REQUIRED       // 유동성 필수
+}

--- a/src/main/java/com/banklab/typetest/domain/enums/InvestmentStyle.java
+++ b/src/main/java/com/banklab/typetest/domain/enums/InvestmentStyle.java
@@ -1,0 +1,5 @@
+package com.banklab.typetest.domain.enums;
+
+public enum InvestmentStyle {
+    LUMP_SUM, REGULAR
+}

--- a/src/main/java/com/banklab/typetest/domain/enums/PeriodRange.java
+++ b/src/main/java/com/banklab/typetest/domain/enums/PeriodRange.java
@@ -1,0 +1,5 @@
+package com.banklab.typetest.domain.enums;
+
+public enum PeriodRange {
+    SHORT_TERM, LONG_TERM
+}

--- a/src/main/java/com/banklab/typetest/domain/enums/Priority.java
+++ b/src/main/java/com/banklab/typetest/domain/enums/Priority.java
@@ -1,0 +1,5 @@
+package com.banklab.typetest.domain.enums;
+
+public enum Priority {
+    SAFETY, RETURN
+}

--- a/src/main/java/com/banklab/typetest/domain/enums/QuestionType.java
+++ b/src/main/java/com/banklab/typetest/domain/enums/QuestionType.java
@@ -1,0 +1,5 @@
+package com.banklab.typetest.domain.enums;
+
+public enum QuestionType {
+    PERSONALITY, CONSTRAINT, DETAIL, PREFERENCE
+}

--- a/src/main/java/com/banklab/typetest/domain/enums/ReturnRange.java
+++ b/src/main/java/com/banklab/typetest/domain/enums/ReturnRange.java
@@ -1,0 +1,5 @@
+package com.banklab.typetest.domain.enums;
+
+public enum ReturnRange {
+    UNDER_3, OVER_3
+}

--- a/src/main/java/com/banklab/typetest/domain/enums/RiskRange.java
+++ b/src/main/java/com/banklab/typetest/domain/enums/RiskRange.java
@@ -1,0 +1,5 @@
+package com.banklab.typetest.domain.enums;
+
+public enum RiskRange {
+    LOW_RISK, HIGH_RISK
+}

--- a/src/main/java/com/banklab/typetest/dto/AnswerDTO.java
+++ b/src/main/java/com/banklab/typetest/dto/AnswerDTO.java
@@ -1,6 +1,6 @@
 package com.banklab.typetest.dto;
 
-import com.banklab.typetest.domain.ChoiceType;
+import com.banklab.typetest.domain.enums.ChoiceType;
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/banklab/typetest/dto/RecommendedProductDTO.java
+++ b/src/main/java/com/banklab/typetest/dto/RecommendedProductDTO.java
@@ -20,7 +20,7 @@ public class RecommendedProductDTO {
     private String companyName;
     private RiskLevel riskLevel;
     private String riskReason;
-    
+
     // 실제 금리 정보
     private String interestRate;    // 실제 금리 정보 (예: "연 2.50~2.50%" 또는 "연 2.45~2.50%")
 

--- a/src/main/java/com/banklab/typetest/dto/TypeTestResultDTO.java
+++ b/src/main/java/com/banklab/typetest/dto/TypeTestResultDTO.java
@@ -18,7 +18,6 @@ public class TypeTestResultDTO {
     private String investmentTypeDesc;
     private String message;
     private List<RecommendedProductDTO> recommendedProducts;
-
     public static TypeTestResultDTO success(Long userId, Long investmentTypeId, String investmentTypeName, String investmentTypeDesc, String message) {
         return TypeTestResultDTO.builder()
                 .userId(userId)

--- a/src/main/java/com/banklab/typetest/dto/TypeTestResultDTO.java
+++ b/src/main/java/com/banklab/typetest/dto/TypeTestResultDTO.java
@@ -18,6 +18,7 @@ public class TypeTestResultDTO {
     private String investmentTypeDesc;
     private String message;
     private List<RecommendedProductDTO> recommendedProducts;
+
     public static TypeTestResultDTO success(Long userId, Long investmentTypeId, String investmentTypeName, String investmentTypeDesc, String message) {
         return TypeTestResultDTO.builder()
                 .userId(userId)

--- a/src/main/java/com/banklab/typetest/mapper/InvestmentTypeMapper.java
+++ b/src/main/java/com/banklab/typetest/mapper/InvestmentTypeMapper.java
@@ -4,5 +4,10 @@ import com.banklab.typetest.domain.InvestmentType;
 import org.apache.ibatis.annotations.Param;
 
 public interface InvestmentTypeMapper {
+    /**
+     * 주어진 ID로 InvestmentType을 조회합니다.
+     * @param id 조회할 InvestmentType의 ID
+     * @return 해당 ID에 해당하는 InvestmentType 객체, 없으면 null
+     */
     InvestmentType findById(@Param("id") Long id);
 }

--- a/src/main/java/com/banklab/typetest/mapper/QuestionChoiceScoreMapper.java
+++ b/src/main/java/com/banklab/typetest/mapper/QuestionChoiceScoreMapper.java
@@ -1,6 +1,6 @@
 package com.banklab.typetest.mapper;
 
-import com.banklab.typetest.domain.ChoiceType;
+import com.banklab.typetest.domain.enums.ChoiceType;
 import com.banklab.typetest.domain.QuestionChoiceScore;
 import org.apache.ibatis.annotations.Param;
 

--- a/src/main/java/com/banklab/typetest/mapper/QuestionChoiceScoreMapper.java
+++ b/src/main/java/com/banklab/typetest/mapper/QuestionChoiceScoreMapper.java
@@ -6,5 +6,11 @@ import org.apache.ibatis.annotations.Param;
 
 
 public interface QuestionChoiceScoreMapper {
+    /**
+     * 질문 ID와 선택지를 기준으로 QuestionChoiceScore를 조회한다.
+     * @param questionId 질문 ID
+     * @param choice 질문 ID에 대한 선택지
+     * @return
+     */
     QuestionChoiceScore findByQuestionIdAndChoice(@Param("questionId") Long questionId, @Param("choice") ChoiceType choice);
 }

--- a/src/main/java/com/banklab/typetest/mapper/QuestionMapper.java
+++ b/src/main/java/com/banklab/typetest/mapper/QuestionMapper.java
@@ -1,9 +1,17 @@
 package com.banklab.typetest.mapper;
 
 import com.banklab.typetest.domain.Question;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
+@Mapper
 public interface QuestionMapper {
     List<Question> getAllQuestions();
+    
+    /**
+     * 질문 ID로 개별 질문 조회 (새로 추가)
+     */
+    Question findById(@Param("id") Long id);
 }

--- a/src/main/java/com/banklab/typetest/mapper/QuestionMapper.java
+++ b/src/main/java/com/banklab/typetest/mapper/QuestionMapper.java
@@ -8,10 +8,14 @@ import java.util.List;
 
 @Mapper
 public interface QuestionMapper {
+    /**
+     * 모든 질문지를 조회한다.
+     * @return 질문지 목록
+     */
     List<Question> getAllQuestions();
     
     /**
-     * 질문 ID로 개별 질문 조회 (새로 추가)
+     * 질문 ID로 개별 질문 조회
      */
     Question findById(@Param("id") Long id);
 }

--- a/src/main/java/com/banklab/typetest/mapper/UserInvestmentConstraintsMapper.java
+++ b/src/main/java/com/banklab/typetest/mapper/UserInvestmentConstraintsMapper.java
@@ -8,19 +8,23 @@ import java.util.List;
 
 @Mapper
 public interface UserInvestmentConstraintsMapper {
-    
+
     /**
      * 사용자의 활성 제약조건 목록 조회
+     * @param userId
+     * @return
      */
     List<UserInvestmentConstraints> findActiveConstraintsByUserId(@Param("userId") Long userId);
-    
+
     /**
      * 사용자 제약조건 저장
+     * @param constraints
      */
     void insertUserInvestmentConstraints(UserInvestmentConstraints constraints);
-    
+
     /**
      * 사용자의 모든 제약조건 비활성화
+     * @param userId
      */
     void deactivateAllConstraints(@Param("userId") Long userId);
 }

--- a/src/main/java/com/banklab/typetest/mapper/UserInvestmentConstraintsMapper.java
+++ b/src/main/java/com/banklab/typetest/mapper/UserInvestmentConstraintsMapper.java
@@ -1,6 +1,7 @@
 package com.banklab.typetest.mapper;
 
 import com.banklab.typetest.domain.UserInvestmentConstraints;
+import com.banklab.typetest.domain.enums.ConstraintType;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -27,4 +28,23 @@ public interface UserInvestmentConstraintsMapper {
      * @param userId
      */
     void deactivateAllConstraints(@Param("userId") Long userId);
+
+    /**
+     * 특정 사용자의 특정 제약조건 조회
+     * @param userId
+     * @param constraintType
+     * @return
+     */
+    UserInvestmentConstraints findByUserIdAndConstraintType(
+        @Param("userId") Long userId, 
+        @Param("constraintType") ConstraintType constraintType);
+
+    /**
+     * 특정 제약조건 활성화
+     * @param userId
+     * @param constraintType
+     */
+    void activateConstraint(
+        @Param("userId") Long userId, 
+        @Param("constraintType") ConstraintType constraintType);
 }

--- a/src/main/java/com/banklab/typetest/mapper/UserInvestmentConstraintsMapper.java
+++ b/src/main/java/com/banklab/typetest/mapper/UserInvestmentConstraintsMapper.java
@@ -1,0 +1,26 @@
+package com.banklab.typetest.mapper;
+
+import com.banklab.typetest.domain.UserInvestmentConstraints;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface UserInvestmentConstraintsMapper {
+    
+    /**
+     * 사용자의 활성 제약조건 목록 조회
+     */
+    List<UserInvestmentConstraints> findActiveConstraintsByUserId(@Param("userId") Long userId);
+    
+    /**
+     * 사용자 제약조건 저장
+     */
+    void insertUserInvestmentConstraints(UserInvestmentConstraints constraints);
+    
+    /**
+     * 사용자의 모든 제약조건 비활성화
+     */
+    void deactivateAllConstraints(@Param("userId") Long userId);
+}

--- a/src/main/java/com/banklab/typetest/mapper/UserInvestmentProfileMapper.java
+++ b/src/main/java/com/banklab/typetest/mapper/UserInvestmentProfileMapper.java
@@ -6,19 +6,23 @@ import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface UserInvestmentProfileMapper {
-    
+
     /**
      * 사용자 투자 프로필 조회
+     * @param userId
+     * @return
      */
     UserInvestmentProfile findByUserId(@Param("userId") Long userId);
-    
+
     /**
      * 사용자 투자 프로필 저장
+     * @param profile
      */
     void insertUserInvestmentProfile(UserInvestmentProfile profile);
-    
+
     /**
      * 사용자 투자 프로필 업데이트
+     * @param profile
      */
     void updateUserInvestmentProfile(UserInvestmentProfile profile);
 }

--- a/src/main/java/com/banklab/typetest/mapper/UserInvestmentProfileMapper.java
+++ b/src/main/java/com/banklab/typetest/mapper/UserInvestmentProfileMapper.java
@@ -1,0 +1,24 @@
+package com.banklab.typetest.mapper;
+
+import com.banklab.typetest.domain.UserInvestmentProfile;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface UserInvestmentProfileMapper {
+    
+    /**
+     * 사용자 투자 프로필 조회
+     */
+    UserInvestmentProfile findByUserId(@Param("userId") Long userId);
+    
+    /**
+     * 사용자 투자 프로필 저장
+     */
+    void insertUserInvestmentProfile(UserInvestmentProfile profile);
+    
+    /**
+     * 사용자 투자 프로필 업데이트
+     */
+    void updateUserInvestmentProfile(UserInvestmentProfile profile);
+}

--- a/src/main/java/com/banklab/typetest/mapper/UserInvestmentTypeMapper.java
+++ b/src/main/java/com/banklab/typetest/mapper/UserInvestmentTypeMapper.java
@@ -3,8 +3,25 @@ package com.banklab.typetest.mapper;
 import com.banklab.typetest.domain.UserInvestmentType;
 import org.apache.ibatis.annotations.Param;
 
+/**
+ * 사용자 투자 유형 정보를 조회, 삽입, 수정하는 매퍼 인터페이스
+ */
 public interface UserInvestmentTypeMapper {
+    /**
+     * 주어진 사용자 ID로 사용자 투자 유형 정보를 조회합니다.
+     * @param userId 사용자 ID
+     * @return UserInvestmentType 객체
+     */
     UserInvestmentType findByUserId(@Param("userId") Long userId);
+
+    /**
+     * 사용자 투자 유형 정보를 삽입합니다.
+     * @param userInvestmentType 삽입할 UserInvestmentType 객체
+     */
     void insertUserInvestmentType(UserInvestmentType userInvestmentType);
+    /**
+     * 사용자 투자 유형 정보를 수정합니다.
+     * @param userInvestmentType 수정할 UserInvestmentType 객체
+     */
     void updateUserInvestmentType(UserInvestmentType userInvestmentType);
 }

--- a/src/main/java/com/banklab/typetest/service/EnhancedProductRecommendationService.java
+++ b/src/main/java/com/banklab/typetest/service/EnhancedProductRecommendationService.java
@@ -1,0 +1,469 @@
+package com.banklab.typetest.service;
+
+import com.banklab.typetest.domain.*;
+import com.banklab.typetest.domain.enums.*;
+import com.banklab.typetest.dto.RecommendedProductDTO;
+import com.banklab.product.domain.*;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * 사용자 투자 프로필을 기반으로 한 맞춤형 상품 추천 서비스
+ * 기존 투자유형별 추천에서 사용자의 상세 프로필과 제약조건을 추가 고려
+ * AI를 활용한 최적 4개 상품 선별
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EnhancedProductRecommendationService {
+
+    private final ProductRecommendationService fallbackRecommendationService;
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${ai.claude.api-key:}")
+    private String apiKey;
+
+    private final String apiUrl = "https://api.anthropic.com/v1/messages";
+
+    /**
+     * 메인 추천 메서드: 기존 추천 상품에서 사용자 프로필 기반 Best 4 선별
+     */
+    public List<RecommendedProductDTO> getFilteredRecommendedProducts(
+            Long investmentTypeId,
+            List<ConstraintType> constraints,
+            UserInvestmentProfile userProfile) {
+
+        try {
+            log.info("맞춤형 상품 추천 시작 - 투자유형: {}, 제약조건: {}, 프로필: {}",
+                    investmentTypeId, constraints, userProfile);
+
+            // 1. 기존 추천 시스템에서 상품 목록 가져오기
+            List<RecommendedProductDTO> baseRecommendations = fallbackRecommendationService.getRecommendedProducts(investmentTypeId);
+            log.info("기존 추천 상품 수: {}", baseRecommendations.size());
+
+            // 2. 하드 제약조건 적용 (절대적 필터링)
+            List<RecommendedProductDTO> constraintFiltered = applyConstraintsToRecommendations(baseRecommendations, constraints);
+            log.info("제약조건 적용 후: {}", constraintFiltered.size());
+
+            // 3. 4개 이하면 그대로 반환
+            if (constraintFiltered.size() <= 4) {
+                log.info("필터링 후 4개 이하이므로 전체 반환: {}", constraintFiltered.size());
+                return constraintFiltered;
+            }
+
+            // 4. AI 기반 최적 4개 선별 (API 키가 있을 때만)
+            if (apiKey != null && !apiKey.trim().isEmpty()) {
+                return selectBest4WithAI(constraintFiltered, userProfile, constraints, investmentTypeId);
+            } else {
+                // 5. AI 없을 때는 규칙 기반 선별
+                return selectBest4WithRules(constraintFiltered, userProfile, constraints);
+            }
+
+        } catch (Exception e) {
+            log.error("맞춤형 추천 시스템 오류, 기존 추천으로 fallback", e);
+            return fallbackRecommendationService.getRecommendedProducts(investmentTypeId);
+        }
+    }
+
+    /**
+     * 하드 제약조건 적용 (절대적 필터링)
+     */
+    private List<RecommendedProductDTO> applyConstraintsToRecommendations(
+            List<RecommendedProductDTO> recommendations,
+            List<ConstraintType> constraints) {
+
+        if (constraints == null || constraints.isEmpty()) {
+            log.info("제약조건이 없으므로 모든 추천 상품 반환");
+            return recommendations;
+        }
+
+        List<RecommendedProductDTO> filtered = recommendations.stream()
+                .filter(product -> {
+                    // 필터링 조건 추가
+                    if (constraints.contains(ConstraintType.HIGH_RISK_FORBIDDEN) &&
+                        "HIGH".equals(product.getRiskLevel())) {
+                        log.debug("고위험 상품 제외: {}", product.getProductName());
+                        return false;
+                    }
+                    return true;
+                })
+                .collect(Collectors.toList());
+
+        log.info("제약조건 적용 후 필터링된 상품 개수: {}", filtered.size());
+        return filtered;
+    }
+
+    /**
+     * AI 기반 최적 4개 선별
+     */
+    private List<RecommendedProductDTO> selectBest4WithAI(
+            List<RecommendedProductDTO> filteredProducts,
+            UserInvestmentProfile userProfile,
+            List<ConstraintType> constraints,
+            Long investmentTypeId) {
+
+        try {
+            String aiPrompt = generateAIPrompt(filteredProducts, userProfile, constraints, investmentTypeId);
+            String response = callClaudeApi(aiPrompt);
+            List<Integer> selectedIndices = parseAIResponse(response);
+
+            // AI가 선택한 인덱스에 해당하는 상품들 반환
+            List<RecommendedProductDTO> finalRecommendations = new ArrayList<>();
+            for (Integer index : selectedIndices) {
+                if (index >= 0 && index < filteredProducts.size()) {
+                    finalRecommendations.add(filteredProducts.get(index));
+                }
+            }
+
+            log.info("AI 추천 완료: {} 개 상품 선별", finalRecommendations.size());
+            return finalRecommendations.isEmpty() ?
+                selectBest4WithRules(filteredProducts, userProfile, constraints) :
+                finalRecommendations;
+
+        } catch (Exception e) {
+            log.error("AI 추천 호출 실패, 규칙 기반으로 fallback", e);
+            return selectBest4WithRules(filteredProducts, userProfile, constraints);
+        }
+    }
+
+    /**
+     * 규칙 기반 최적 4개 선별 (AI 대안)
+     */
+    private List<RecommendedProductDTO> selectBest4WithRules(
+            List<RecommendedProductDTO> filteredProducts,
+            UserInvestmentProfile userProfile,
+            List<ConstraintType> constraints) {
+
+        log.info("규칙 기반 상품 선별 시작");
+
+        // 1. 사용자 프로필에 따른 점수 계산
+        List<ProductScore> scoredProducts = filteredProducts.stream()
+                .map(product -> new ProductScore(product, calculateScore(product, userProfile, constraints)))
+                .sorted((a, b) -> Double.compare(b.score, a.score))
+                .collect(Collectors.toList());
+
+        // 2. 상위 4개 선택 (다양성 고려)
+        List<RecommendedProductDTO> selectedProducts = new ArrayList<>();
+        Set<String> selectedCompanies = new HashSet<>();
+        Set<ProductType> selectedTypes = new HashSet<>();
+
+        // 첫 번째 패스: 점수 순으로 다양성 고려하여 선택
+        for (ProductScore scored : scoredProducts) {
+            if (selectedProducts.size() >= 4) break;
+
+            RecommendedProductDTO product = scored.product;
+            boolean shouldSelect = selectedProducts.size() < 2 || // 처음 2개는 무조건 선택
+                    !selectedCompanies.contains(product.getCompanyName()) || // 다른 회사
+                    !selectedTypes.contains(product.getProductType()); // 다른 상품 타입
+
+            if (shouldSelect) {
+                selectedProducts.add(product);
+                selectedCompanies.add(product.getCompanyName());
+                if (product.getProductType() != null) {
+                    selectedTypes.add(product.getProductType());
+                }
+            }
+        }
+
+        // 두 번째 패스: 4개 미만이면 점수 순으로 채우기
+        for (ProductScore scored : scoredProducts) {
+            if (selectedProducts.size() >= 4) break;
+            if (!selectedProducts.contains(scored.product)) {
+                selectedProducts.add(scored.product);
+            }
+        }
+
+        log.info("규칙 기반 선별 완료: {} 개 상품", selectedProducts.size());
+        return selectedProducts;
+    }
+
+    /**
+     * 사용자 프로필 기반 상품 점수 계산
+     */
+    private double calculateScore(RecommendedProductDTO product, UserInvestmentProfile profile, List<ConstraintType> constraints) {
+        double score = 50.0; // 기본 점수
+
+        if (profile == null) return score;
+
+        // 1. 위험도 매칭 (가장 중요한 요소)
+        if (product.getRiskLevel() != null) {
+            if (profile.getLossToleranceRange() == RiskRange.LOW_RISK) {
+                if ("LOW".equals(product.getRiskLevel().name())) score += 20;
+                else if ("MEDIUM".equals(product.getRiskLevel().name())) score += 10;
+                else score -= 10; // HIGH 위험
+            } else {
+                if ("HIGH".equals(product.getRiskLevel().name())) score += 15;
+                else if ("MEDIUM".equals(product.getRiskLevel().name())) score += 20;
+                else score += 10; // LOW 위험도 괜찮음
+            }
+        }
+
+        // 2. 투자 우선순위 매칭
+        if (profile.getPriority() == Priority.SAFETY) {
+            if (product.getRiskLevel() != null && "LOW".equals(product.getRiskLevel().name())) score += 15;
+            if (product.getProductType() == ProductType.DEPOSIT) score += 10;
+        } else if (profile.getPriority() == Priority.RETURN) {
+            if (product.getRiskLevel() != null && !"LOW".equals(product.getRiskLevel().name())) score += 10;
+        }
+
+        // 3. 투자 방식 매칭
+        if (profile.getInvestmentStyle() == InvestmentStyle.REGULAR) {
+            if (product.getProductType() == ProductType.SAVINGS) score += 10;
+        } else if (profile.getInvestmentStyle() == InvestmentStyle.LUMP_SUM) {
+            if (product.getProductType() == ProductType.DEPOSIT) score += 10;
+        }
+
+        // 4. 투자 기간 매칭 (간접적 추정)
+        if (profile.getInvestmentPeriodRange() == PeriodRange.SHORT_TERM) {
+            if (product.getProductType() == ProductType.DEPOSIT) score += 5;
+        } else {
+            if (product.getProductType() == ProductType.SAVINGS) score += 5;
+        }
+
+        return score;
+    }
+
+    /**
+     * AI 프롬프트 생성
+     */
+    private String generateAIPrompt(
+            List<RecommendedProductDTO> products,
+            UserInvestmentProfile profile,
+            List<ConstraintType> constraints,
+            Long investmentTypeId) {
+
+        StringBuilder prompt = new StringBuilder();
+
+        String investmentTypeName = getInvestmentTypeName(investmentTypeId);
+
+        prompt.append(String.format("""
+            당신은 전문 금융상품 추천 AI입니다. 
+            
+            사용자의 투자성향(%s)에 맞게 이미 필터링된 상품들 중에서,
+            사용자의 **상세 프로필**을 추가로 고려하여 **가장 적합한 4개**를 선별해주세요.
+            
+            ## 📊 사용자 프로필
+            - **투자 성향**: %s
+            - **투자 가능 금액**: %s
+            - **목표 수익률**: %s  
+            - **투자 기간**: %s
+            - **손실 감수 한도**: %s
+            - **투자 방식**: %s
+            - **우선순위**: %s
+            - **제약조건**: %s
+            
+            ## 📋 상품 목록 (%d개)
+            """,
+            investmentTypeName,
+            investmentTypeName,
+            getAmountRangeDescription(profile != null ? profile.getAvailableAmountRange() : null),
+            getReturnRangeDescription(profile != null ? profile.getTargetReturnRange() : null),
+            getPeriodRangeDescription(profile != null ? profile.getInvestmentPeriodRange() : null),
+            getRiskRangeDescription(profile != null ? profile.getLossToleranceRange() : null),
+            getInvestmentStyleDescription(profile != null ? profile.getInvestmentStyle() : null),
+            getPriorityDescription(profile != null ? profile.getPriority() : null),
+            getConstraintsDescription(constraints),
+            products.size()
+        ));
+
+        for (int i = 0; i < products.size(); i++) {
+            RecommendedProductDTO product = products.get(i);
+            prompt.append(String.format("""
+                
+                ### 상품 %d
+                - 회사: %s
+                - 상품명: %s
+                - 분류: %s
+                - 위험도: %s
+                - 금리: %s
+                """,
+                i,
+                product.getCompanyName(),
+                product.getProductName(),
+                getProductTypeDescription(product.getProductType() != null ? product.getProductType().name() : "UNKNOWN"),
+                getRiskLevelBadge(product.getRiskLevel() != null ? product.getRiskLevel().name() : "MEDIUM"),
+                product.getInterestRate() != null ? product.getInterestRate() : "정보없음"
+            ));
+        }
+
+        prompt.append("""
+            
+            ## 선별 요청
+            
+            사용자 프로필을 종합적으로 고려하여 **가장 적합한 4개 상품의 인덱스**를 선별해주세요.
+            
+            **응답 형식:**
+            [인덱스1, 인덱스2, 인덱스3, 인덱스4]
+            
+            예시: [0, 2, 5, 8]
+            
+            **중요**: JSON 배열 형태로만 응답하세요.
+            """);
+
+        return prompt.toString();
+    }
+
+    private String getAmountRangeDescription(AmountRange range) {
+        if (range == null) return "정보 없음";
+        return switch (range) {
+            case UNDER_500 -> "500만원 미만";
+            case OVER_500 -> "500만원 이상";
+        };
+    }
+
+    private String getReturnRangeDescription(ReturnRange range) {
+        if (range == null) return "정보 없음";
+        return switch (range) {
+            case UNDER_3 -> "연 3% 이하";
+            case OVER_3 -> "연 3% 초과";
+        };
+    }
+
+    private String getPeriodRangeDescription(PeriodRange range) {
+        if (range == null) return "정보 없음";
+        return switch (range) {
+            case SHORT_TERM -> "1년 이하 단기";
+            case LONG_TERM -> "1년 초과 장기";
+        };
+    }
+
+    private String getRiskRangeDescription(RiskRange range) {
+        if (range == null) return "정보 없음";
+        return switch (range) {
+            case LOW_RISK -> "5% 이하 손실만 감수";
+            case HIGH_RISK -> "5% 초과 손실 감수 가능";
+        };
+    }
+
+    private String getInvestmentStyleDescription(InvestmentStyle style) {
+        if (style == null) return "정보 없음";
+        return switch (style) {
+            case LUMP_SUM -> "일시납";
+            case REGULAR -> "적립식";
+        };
+    }
+
+    private String getPriorityDescription(Priority priority) {
+        if (priority == null) return "정보 없음";
+        return switch (priority) {
+            case SAFETY -> "안전성 우선";
+            case RETURN -> "수익성 우선";
+        };
+    }
+
+    private String getConstraintsDescription(List<ConstraintType> constraints) {
+        if (constraints == null || constraints.isEmpty()) return "특별한 제약 없음";
+
+        List<String> descriptions = constraints.stream()
+                .map(constraint -> switch (constraint) {
+                    case PRINCIPAL_GUARANTEE -> "원금보장 필수";
+                    case HIGH_RISK_FORBIDDEN -> "고위험 상품 금지";
+                    case LIQUIDITY_REQUIRED -> "유동성 필수";
+                })
+                .toList();
+
+        return String.join(", ", descriptions);
+    }
+
+    private String getProductTypeDescription(String productType) {
+        return switch (productType) {
+            case "DEPOSIT" -> "정기예금";
+            case "SAVINGS" -> "적금";
+            case "LOAN" -> "대출";
+            default -> "기타";
+        };
+    }
+
+    private String getRiskLevelBadge(String riskLevel) {
+        return switch (riskLevel) {
+            case "LOW" -> "저위험";
+            case "MEDIUM" -> "중위험";
+            case "HIGH" -> "고위험";
+            default -> "미분류";
+        };
+    }
+
+    private String getInvestmentTypeName(Long investmentTypeId) {
+        switch (investmentTypeId.intValue()) {
+            case 1: return "안전형";
+            case 2: return "중립형";
+            case 3: return "공격형";
+            default: return "안전형";
+        }
+    }
+
+    /**
+     * Claude API 호출
+     */
+    private String callClaudeApi(String prompt) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("x-api-key", apiKey);
+        headers.set("anthropic-version", "2023-06-01");
+
+        Map<String, Object> requestBody = Map.of(
+            "model", "claude-3-haiku-20240307",
+            "max_tokens", 1000,
+            "messages", List.of(
+                Map.of("role", "user", "content", prompt)
+            )
+        );
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+        ResponseEntity<Map> response = restTemplate.postForEntity(apiUrl, entity, Map.class);
+
+        Map<String, Object> responseBody = response.getBody();
+        List<Map<String, Object>> content = (List<Map<String, Object>>) responseBody.get("content");
+        return (String) content.get(0).get("text");
+    }
+
+    /**
+     * AI 응답 파싱
+     */
+    private List<Integer> parseAIResponse(String response) {
+        try {
+            log.info("AI 응답: {}", response);
+
+            String jsonPart = extractJsonFromResponse(response);
+            List<Integer> indices = objectMapper.readValue(jsonPart, new TypeReference<List<Integer>>() {});
+
+            return indices.stream().limit(4).collect(Collectors.toList());
+
+        } catch (Exception e) {
+            log.error("AI 응답 파싱 실패: {}", response, e);
+            return List.of(0, 1, 2, 3);
+        }
+    }
+
+    private String extractJsonFromResponse(String response) {
+        int start = response.indexOf("[");
+        int end = response.lastIndexOf("]") + 1;
+        if (start >= 0 && end > start) {
+            return response.substring(start, end);
+        }
+        return "[0, 1, 2, 3]";
+    }
+
+    /**
+     * 상품 점수 매핑 클래스
+     */
+    private static class ProductScore {
+        final RecommendedProductDTO product;
+        final double score;
+
+        ProductScore(RecommendedProductDTO product, double score) {
+            this.product = product;
+            this.score = score;
+        }
+    }
+}

--- a/src/main/java/com/banklab/typetest/service/ProductRecommendationServiceImpl.java
+++ b/src/main/java/com/banklab/typetest/service/ProductRecommendationServiceImpl.java
@@ -38,7 +38,7 @@ public class ProductRecommendationServiceImpl implements ProductRecommendationSe
     public List<RecommendedProductDTO> getRecommendedProducts(Long investmentTypeId) {
         try {
             log.info("추천상품 조회 시작 - investmentTypeId: {}", investmentTypeId);
-            
+
             // 투자성향을 RiskLevel로 매핑
             RiskLevel riskLevel = mapInvestmentTypeToRiskLevel(investmentTypeId);
             log.info("매핑된 RiskLevel: {}", riskLevel);
@@ -46,19 +46,19 @@ public class ProductRecommendationServiceImpl implements ProductRecommendationSe
             // 해당 위험도의 상품들 조회
             List<ProductRiskRating> riskRatings = productRiskRatingMapper.selectByRiskLevel(riskLevel);
             log.info("조회된 상품 개수: {}", riskRatings.size());
-            
+
             // 각 상품의 실제 정보를 조회해서 메타데이터 보완
             List<ProductRiskRating> enrichedRatings = enrichProductMetadata(riskRatings);
-            
+
             // 배치로 모든 상품의 금리 정보 조회
             Map<String, ProductRateInfo> rateInfoMap = productRateService.getBatchProductRates(enrichedRatings);
             log.info("금리 정보 조회 완료: {} 개", rateInfoMap.size());
-            
+
             // ProductRiskRating을 RecommendedProductDTO로 변환
             List<RecommendedProductDTO> result = enrichedRatings.stream()
                     .map(rating -> convertToRecommendedProductDTO(rating, rateInfoMap))
                     .collect(Collectors.toList());
-            
+
             log.info("변환된 추천상품 개수: {}", result.size());
             return result;
                     

--- a/src/main/java/com/banklab/typetest/service/ProductRecommendationServiceImpl.java
+++ b/src/main/java/com/banklab/typetest/service/ProductRecommendationServiceImpl.java
@@ -88,7 +88,7 @@ public class ProductRecommendationServiceImpl implements ProductRecommendationSe
     private List<ProductRiskRating> enrichProductMetadata(List<ProductRiskRating> riskRatings) {
         log.info("상품 메타데이터 보완 시작: {} 개", riskRatings.size());
         
-        // 모든 상품을 미리 조회해서 맵으로 만들기
+        // 모든 상품을 미리 조회해서 map으로 만들어 놓는다.
         Map<Long, DepositProduct> depositMap = depositProductMapper.findAllDepositProducts().stream()
                 .collect(Collectors.toMap(DepositProduct::getId, p -> p));
         Map<Long, SavingsProduct> savingsMap = savingsProductMapper.findAllSavingsProducts().stream()

--- a/src/main/java/com/banklab/typetest/service/TypeTestService.java
+++ b/src/main/java/com/banklab/typetest/service/TypeTestService.java
@@ -29,4 +29,5 @@ public interface TypeTestService {
      * @return 테스트 결과 DTO
      */
     TypeTestResultDTO getTestResultByUserId(Long userId);
+    TypeTestResultDTO getAllProductsByType(Long userId);
 }

--- a/src/main/java/com/banklab/typetest/service/TypeTestService.java
+++ b/src/main/java/com/banklab/typetest/service/TypeTestService.java
@@ -29,5 +29,11 @@ public interface TypeTestService {
      * @return 테스트 결과 DTO
      */
     TypeTestResultDTO getTestResultByUserId(Long userId);
+    /**
+     * 사용자 유형별로 모든 상품을 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 테스트 결과 DTO
+     */
     TypeTestResultDTO getAllProductsByType(Long userId);
 }

--- a/src/main/java/com/banklab/typetest/service/TypeTestServiceImpl.java
+++ b/src/main/java/com/banklab/typetest/service/TypeTestServiceImpl.java
@@ -1,26 +1,18 @@
 package com.banklab.typetest.service;
 
-import com.banklab.typetest.domain.ChoiceType;
-import com.banklab.typetest.domain.InvestmentType;
-import com.banklab.typetest.domain.Question;
-import com.banklab.typetest.domain.QuestionChoiceScore;
-import com.banklab.typetest.domain.UserInvestmentType;
+import com.banklab.typetest.domain.*;
+import com.banklab.typetest.domain.enums.*;
 import com.banklab.typetest.dto.AnswerDTO;
 import com.banklab.typetest.dto.RecommendedProductDTO;
 import com.banklab.typetest.dto.TypeTestResultDTO;
-import com.banklab.typetest.mapper.InvestmentTypeMapper;
-import com.banklab.typetest.mapper.QuestionChoiceScoreMapper;
-import com.banklab.typetest.mapper.QuestionMapper;
-import com.banklab.typetest.mapper.UserInvestmentTypeMapper;
+import com.banklab.typetest.mapper.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -31,60 +23,267 @@ public class TypeTestServiceImpl implements TypeTestService {
     private final QuestionChoiceScoreMapper questionChoiceScoreMapper;
     private final InvestmentTypeMapper investmentTypeMapper;
     private final UserInvestmentTypeMapper userInvestmentTypeMapper;
+    private final UserInvestmentProfileMapper userInvestmentProfileMapper;
+    private final UserInvestmentConstraintsMapper userInvestmentConstraintsMapper;
     private final ProductRecommendationService productRecommendationService;
+    private final EnhancedProductRecommendationService enhancedProductRecommendationService;
 
+    /**
+     * 질문지 전체 조회
+     * @return 질문지 목록 반환
+     */
     @Override
     public List<Question> getAllQuestions() {
         return questionMapper.getAllQuestions();
     }
 
+    /**
+     * 사용자의 유형검사 결과 제출
+     * @param payload 사용자의 답변 데이터
+     * @param memberId JWT에서 추출한 회원 ID
+     * @return
+     */
     @Override
     public TypeTestResultDTO submitAnswersWithMemberId(Map<String, Object> payload, Long memberId) {
         try {
-            // memberId를 userId로 사용
             List<AnswerDTO> answers = parseAnswers(payload);
-            Long bestTypeId = calculateBestInvestmentType(answers);
-            if (bestTypeId == null) {
-                return createFailResult("점수 계산 결과가 없습니다");
-            }
+
+            //답변을 기본검사, 제한검사, 상세검사, 선호검사로 나눈다
+            Map<QuestionType, List<AnswerDTO>> categorizedAnswers = categorizeAnswers(answers);
+            //사용자의 답변에 따른 제약조건을 추가한다(ex: 안정형 제한 질문은 추후에 공격형 질문에 답해도 안정형 질문만 나오게)
+            List<ConstraintType> constraints = analyzeConstraints(categorizedAnswers.get(QuestionType.CONSTRAINT));
+            //투자 유형을 반환한다.
+            Long bestTypeId = calculateBestInvestmentTypeWithConstraints(
+                categorizedAnswers.get(QuestionType.PERSONALITY),
+                constraints
+            );
+            // 개인 맞춤화 상품 추천을 위한 userProfile
+            UserInvestmentProfile userProfile = createUserProfile(
+                categorizedAnswers.get(QuestionType.DETAIL),
+                categorizedAnswers.get(QuestionType.PREFERENCE)
+            );
+
+            saveUserData(memberId, bestTypeId, userProfile, constraints);
             InvestmentType investmentType = getInvestmentType(bestTypeId);
-            saveUserInvestmentType(memberId, bestTypeId);
-            List<RecommendedProductDTO> recommendedProducts = getRecommendedProducts(bestTypeId);
-            return createSuccessResult(memberId, investmentType, recommendedProducts);
-        } catch (IllegalArgumentException e) {
-            log.warn("투자성향 테스트 실행 중 잘못된 파라미터: {}", e.getMessage());
-            return createFailResult(e.getMessage());
+
+            return TypeTestResultDTO.builder()
+                .userId(memberId)
+                .investmentTypeId(investmentType.getId())
+                .investmentTypeName(investmentType.getInvestmentTypeName())
+                .message("유형검사 답변 저장 및 투자유형 계산 완료")
+                .build();
         } catch (Exception e) {
-            log.error("투자성향 테스트 실행 중 예상치 못한 오류 발생", e);
-            return createFailResult("서버 오류: " + e.getMessage());
+            log.error("유형검사 답변 저장 중 오류", e);
+            return createFailResult("유형검사 답변 저장 실패: " + e.getMessage());
         }
     }
 
+    /**
+     * 사용자 투자 성향 결과가 있는지 판별
+     * 결과가 있다면, 해당 유저의 투자 성향과 AI로 추천된 상품 4개를 반환한다.
+     * @param userId 사용자 ID
+     * @return
+     */
     @Override
     public TypeTestResultDTO getTestResultByUserId(Long userId) {
         try {
-            // 사용자의 투자성향 조회
             UserInvestmentType userInvestmentType = userInvestmentTypeMapper.findByUserId(userId);
             if (userInvestmentType == null) {
                 return createFailResult("해당 사용자의 투자성향 테스트 결과를 찾을 수 없습니다.");
             }
-
-            // 투자성향 정보 조회
+            //투자유형 반환
             InvestmentType investmentType = getInvestmentType(userInvestmentType.getInvestmentTypeId());
 
-            // 추천상품 조회
-            List<RecommendedProductDTO> recommendedProducts = getRecommendedProducts(userInvestmentType.getInvestmentTypeId());
+            //추천상품 반환
+            List<ConstraintType> constraints = getUserConstraints(userId);
+            UserInvestmentProfile userProfile = userInvestmentProfileMapper.findByUserId(userId);
+            List<RecommendedProductDTO> recommendedProducts = getFilteredRecommendedProducts(
+                userInvestmentType.getInvestmentTypeId(), constraints, userProfile);
 
-            // 결과 반환
+            if (recommendedProducts != null && recommendedProducts.size() > 4) {
+                recommendedProducts = recommendedProducts.subList(0, 4);
+            }
             return createSuccessResult(userId, investmentType, recommendedProducts);
-
         } catch (Exception e) {
             log.error("사용자 테스트 결과 조회 중 오류 발생: userId={}", userId, e);
             return createFailResult("테스트 결과 조회 중 오류가 발생했습니다: " + e.getMessage());
         }
     }
 
+    /**
+     * 사용자의 투자 성향에 맞는 전체 상품 보기
+     * @param userId
+     * @return
+     */
+    @Override
+    public TypeTestResultDTO getAllProductsByType(Long userId) {
+        try {
+            UserInvestmentType userInvestmentType = userInvestmentTypeMapper.findByUserId(userId);
+            if (userInvestmentType == null) {
+                return createFailResult("해당 사용자의 투자성향 테스트 결과를 찾을 수 없습니다.");
+            }
+            InvestmentType investmentType = getInvestmentType(userInvestmentType.getInvestmentTypeId());
+            List<RecommendedProductDTO> allProducts = productRecommendationService.getRecommendedProducts(
+                userInvestmentType.getInvestmentTypeId()
+            );
+            return TypeTestResultDTO.builder()
+                .userId(userId)
+                .investmentTypeId(investmentType.getId())
+                .investmentTypeName(investmentType.getInvestmentTypeName())
+                .investmentTypeDesc(investmentType.getInvestmentTypeDesc())
+                .recommendedProducts(allProducts)
+                .message("전체 상품 조회 완료")
+                .build();
+        } catch (Exception e) {
+            log.error("전체 상품 조회 중 오류 발생: userId={}", userId, e);
+            return createFailResult("전체 상품 조회 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
 
+    /**
+     * 응답을 질문 타입별로 분류
+     */
+    private Map<QuestionType, List<AnswerDTO>> categorizeAnswers(List<AnswerDTO> answers) {
+        Map<QuestionType, List<AnswerDTO>> categorized = new HashMap<>();
+        
+        for (AnswerDTO answer : answers) {
+            Question question = questionMapper.findById(answer.getQuestionId());
+            if (question != null) {
+                categorized.computeIfAbsent(question.getQuestionType(), k -> new ArrayList<>()).add(answer);
+            }
+        }
+        
+        return categorized;
+    }
+    
+    /**
+     * 제약조건 분석 (하드필터링 조건)
+     */
+    private List<ConstraintType> analyzeConstraints(List<AnswerDTO> constraintAnswers) {
+        List<ConstraintType> constraints = new ArrayList<>();
+        
+        if (constraintAnswers == null) return constraints;
+        
+        for (AnswerDTO answer : constraintAnswers) {
+            switch (answer.getQuestionId().intValue()) {
+                case 5: // 원금 손실 위험
+                    if (answer.getChoice() == ChoiceType.A) {
+                        constraints.add(ConstraintType.PRINCIPAL_GUARANTEE);
+                    }
+                    break;
+                case 6: // 고위험 상품
+                    if (answer.getChoice() == ChoiceType.A) {
+                        constraints.add(ConstraintType.HIGH_RISK_FORBIDDEN);
+                    }
+                    break;
+                case 7: // 중도해지 수수료
+                    if (answer.getChoice() == ChoiceType.A) {
+                        constraints.add(ConstraintType.LIQUIDITY_REQUIRED);
+                    }
+                    break;
+            }
+        }
+        
+        return constraints;
+    }
+    
+    /**
+     * 사용자 프로필 생성
+     */
+    private UserInvestmentProfile createUserProfile(List<AnswerDTO> detailAnswers, List<AnswerDTO> preferenceAnswers) {
+        UserInvestmentProfile.UserInvestmentProfileBuilder builder = UserInvestmentProfile.builder();
+        
+        // DETAIL 응답 처리
+        if (detailAnswers != null) {
+            for (AnswerDTO answer : detailAnswers) {
+                switch (answer.getQuestionId().intValue()) {
+                    case 8: // 투자 가능 금액
+                        builder.availableAmountRange(answer.getChoice() == ChoiceType.A ? AmountRange.UNDER_500 : AmountRange.OVER_500);
+                        break;
+                    case 9: // 희망 수익률
+                        builder.targetReturnRange(answer.getChoice() == ChoiceType.A ? ReturnRange.UNDER_3 : ReturnRange.OVER_3);
+                        break;
+                    case 10: // 투자 기간
+                        builder.investmentPeriodRange(answer.getChoice() == ChoiceType.A ? PeriodRange.SHORT_TERM : PeriodRange.LONG_TERM);
+                        break;
+                    case 11: // 손실 감수 한도
+                        builder.lossToleranceRange(answer.getChoice() == ChoiceType.A ? RiskRange.LOW_RISK : RiskRange.HIGH_RISK);
+                        break;
+                }
+            }
+        }
+        
+        // PREFERENCE 응답 처리
+        if (preferenceAnswers != null) {
+            for (AnswerDTO answer : preferenceAnswers) {
+                switch (answer.getQuestionId().intValue()) {
+                    case 12: // 투자 방식
+                        builder.investmentStyle(answer.getChoice() == ChoiceType.A ? InvestmentStyle.LUMP_SUM : InvestmentStyle.REGULAR);
+                        break;
+                    case 13: // 우선순위
+                        builder.priority(answer.getChoice() == ChoiceType.A ? Priority.SAFETY : Priority.RETURN);
+                        break;
+                }
+            }
+        }
+        
+        return builder.build();
+    }
+    
+    /**
+     * 사용자 데이터 저장
+     */
+    private void saveUserData(Long userId, Long investmentTypeId, UserInvestmentProfile userProfile, List<ConstraintType> constraints) {
+        // 1. 기존 투자유형 저장
+        saveUserInvestmentType(userId, investmentTypeId);
+        
+        // 2. 사용자 프로필 저장
+        userProfile.setUserId(userId);
+        UserInvestmentProfile existingProfile = userInvestmentProfileMapper.findByUserId(userId);
+        if (existingProfile == null) {
+            userInvestmentProfileMapper.insertUserInvestmentProfile(userProfile);
+        } else {
+            userProfile.setId(existingProfile.getId());
+            userInvestmentProfileMapper.updateUserInvestmentProfile(userProfile);
+        }
+        
+        // 3. 제약조건 저장
+        userInvestmentConstraintsMapper.deactivateAllConstraints(userId); // 기존 제약조건 비활성화
+        for (ConstraintType constraintType : constraints) {
+            UserInvestmentConstraints constraint = UserInvestmentConstraints.builder()
+                .userId(userId)
+                .constraintType(constraintType)
+                .isActive(true)
+                .build();
+            userInvestmentConstraintsMapper.insertUserInvestmentConstraints(constraint);
+        }
+    }
+    
+    /**
+     * 제약조건과 프로필을 고려한 필터링된 추천상품 조회
+     */
+    private List<RecommendedProductDTO> getFilteredRecommendedProducts(Long investmentTypeId, List<ConstraintType> constraints, UserInvestmentProfile userProfile) {
+        try {
+            // 새로운 필터링 서비스 사용
+            return enhancedProductRecommendationService.getFilteredRecommendedProducts(investmentTypeId, constraints, userProfile);
+        } catch (Exception e) {
+            log.error("새로운 추천 서비스 오류, 기존 서비스로 fallback: {}", e.getMessage());
+            // 기존 추천 로직으로 fallback
+            return productRecommendationService.getRecommendedProducts(investmentTypeId);
+        }
+    }
+    
+    /**
+     * 사용자 제약조건 조회
+     */
+    private List<ConstraintType> getUserConstraints(Long userId) {
+        return userInvestmentConstraintsMapper.findActiveConstraintsByUserId(userId)
+                .stream()
+                .map(UserInvestmentConstraints::getConstraintType)
+                .collect(Collectors.toList());
+    }
+
+    
     private List<AnswerDTO> parseAnswers(Map<String, Object> payload) {
         Object rawAnswers = payload.get("answers");
         if (!(rawAnswers instanceof List<?> answersRaw)) {
@@ -96,7 +295,6 @@ public class TypeTestServiceImpl implements TypeTestService {
     }
 
     private AnswerDTO parseAnswer(Object answerObj) {
-        // 개별 답변 파싱
         if (!(answerObj instanceof Map<?, ?> answerMap)) {
             throw new IllegalArgumentException("answers 배열의 요소가 올바르지 않습니다.");
         }
@@ -118,19 +316,71 @@ public class TypeTestServiceImpl implements TypeTestService {
         }
     }
 
-    private Long calculateBestInvestmentType(List<AnswerDTO> answers) {
-        // 답변을 기반으로 투자 성향 점수 계산
+    /**
+     * 제약조건을 고려한 투자유형 계산 (새로운 메서드)
+     */
+    private Long calculateBestInvestmentTypeWithConstraints(List<AnswerDTO> personalityAnswers, List<ConstraintType> constraints) {
+        log.info("제약조건을 고려한 투자유형 계산 시작 - 제약조건: {}", constraints);
+        
+        // 1. 기본 성향 점수 계산
         Map<Long, Integer> typeScores = new HashMap<>();
-
-        for (AnswerDTO answer : answers) {
-            addScoreForAnswer(answer, typeScores);
+        if (personalityAnswers != null) {
+            for (AnswerDTO answer : personalityAnswers) {
+                addScoreForAnswer(answer, typeScores);
+            }
         }
-
-        return findTypeWithHighestScore(typeScores);
+        
+        log.info("기본 성향 점수: {}", typeScores);
+        
+        // 2. 제약조건에 따른 투자유형 조정
+        if (constraints != null && !constraints.isEmpty()) {
+            
+            // HIGH_RISK_FORBIDDEN: 고위험 상품 금지 → 공격형 배제
+            if (constraints.contains(ConstraintType.HIGH_RISK_FORBIDDEN)) {
+                log.info("고위험 상품 금지 제약조건 적용 - 공격형 제거");
+                typeScores.remove(3L); // 공격형 완전 제거
+                typeScores.put(1L, typeScores.getOrDefault(1L, 0) + 100); // 안정형 강력 보너스
+                typeScores.put(2L, typeScores.getOrDefault(2L, 0) + 50);  // 중립형 보너스
+            }
+            
+            // PRINCIPAL_GUARANTEE: 원금보장 필수 → 공격형 배제, 안정형 우선
+            if (constraints.contains(ConstraintType.PRINCIPAL_GUARANTEE)) {
+                log.info("원금보장 필수 제약조건 적용 - 공격형 제거, 안정형 우선");
+                typeScores.remove(3L); // 공격형 완전 제거
+                typeScores.put(1L, typeScores.getOrDefault(1L, 0) + 150); // 안정형 최우선
+                typeScores.put(2L, typeScores.getOrDefault(2L, 0) + 30);  // 중립형 약간 보너스
+            }
+            
+            // LIQUIDITY_REQUIRED: 유동성 필수 → 복잡한 상품 배제, 안정형/중립형 우선
+            if (constraints.contains(ConstraintType.LIQUIDITY_REQUIRED)) {
+                log.info("유동성 필수 제약조건 적용 - 안정형/중립형 우선");
+                typeScores.put(3L, Math.max(0, typeScores.getOrDefault(3L, 0) - 50)); // 공격형 감점
+                typeScores.put(1L, typeScores.getOrDefault(1L, 0) + 80); // 안정형 보너스
+                typeScores.put(2L, typeScores.getOrDefault(2L, 0) + 70); // 중립형 보너스
+            }
+        }
+        
+        log.info("제약조건 적용 후 점수: {}", typeScores);
+        
+        Long finalTypeId = findTypeWithHighestScore(typeScores);
+        log.info("최종 결정된 투자유형: {} ({})", finalTypeId, getInvestmentTypeName(finalTypeId));
+        
+        return finalTypeId;
+    }
+    
+    /**
+     * 투자유형 이름 조회 (로깅용)
+     */
+    private String getInvestmentTypeName(Long typeId) {
+        switch (typeId.intValue()) {
+            case 1: return "안정형";
+            case 2: return "중립형"; 
+            case 3: return "공격형";
+            default: return "알 수 없음";
+        }
     }
 
     private void addScoreForAnswer(AnswerDTO answer, Map<Long, Integer> typeScores) {
-        // 답변에 해당하는 점수를 투자 성향 점수에 추가
         QuestionChoiceScore score = questionChoiceScoreMapper
                 .findByQuestionIdAndChoice(answer.getQuestionId(), answer.getChoice());
 
@@ -140,21 +390,18 @@ public class TypeTestServiceImpl implements TypeTestService {
     }
 
     private Long findTypeWithHighestScore(Map<Long, Integer> typeScores) {
-        // 가장 높은 점수를 가진 투자 성향 ID 반환
         return typeScores.entrySet().stream()
                 .max(Map.Entry.comparingByValue())
                 .map(Map.Entry::getKey)
-                .orElse(null);
+                .orElse(1L); // 기본값: 안전형
     }
 
     private InvestmentType getInvestmentType(Long typeId) {
-        // 투자 성향 정보 조회
         return Optional.ofNullable(investmentTypeMapper.findById(typeId))
                 .orElse(createDefaultInvestmentType());
     }
 
     private InvestmentType createDefaultInvestmentType() {
-        // 기본 투자 성향 생성
         InvestmentType defaultType = new InvestmentType();
         defaultType.setInvestmentTypeName("알 수 없음");
         defaultType.setInvestmentTypeDesc("투자성향을 확인할 수 없습니다.");
@@ -162,7 +409,6 @@ public class TypeTestServiceImpl implements TypeTestService {
     }
 
     private void saveUserInvestmentType(Long userId, Long investmentTypeId) {
-        // 사용자 투자 성향 저장
         UserInvestmentType userType = Optional.ofNullable(userInvestmentTypeMapper.findByUserId(userId))
                 .orElse(new UserInvestmentType());
 
@@ -177,30 +423,18 @@ public class TypeTestServiceImpl implements TypeTestService {
         }
     }
 
-    private List<RecommendedProductDTO> getRecommendedProducts(Long investmentTypeId) {
-        // 투자성향에 따른 추천상품 조회
-        try {
-            return productRecommendationService.getRecommendedProducts(investmentTypeId);
-        } catch (Exception e) {
-            log.error("추천상품 조회 중 오류 발생: investmentTypeId={}", investmentTypeId, e);
-            return List.of(); // 빈 리스트 반환
-        }
-    }
-
     private TypeTestResultDTO createSuccessResult(Long userId, InvestmentType investmentType, List<RecommendedProductDTO> recommendedProducts) {
-        // 성공 결과 생성 (추천상품 포함)
         return TypeTestResultDTO.builder()
                 .userId(userId)
                 .investmentTypeId(investmentType.getId())
                 .investmentTypeName(investmentType.getInvestmentTypeName())
                 .investmentTypeDesc(investmentType.getInvestmentTypeDesc())
-                .recommendedProducts(recommendedProducts) // 추천상품 추가
+                .recommendedProducts(recommendedProducts)
                 .message("투자유형 계산이 완료되었습니다.")
                 .build();
     }
 
     private TypeTestResultDTO createFailResult(String message) {
-        // 실패 결과 생성
         return TypeTestResultDTO.builder()
                 .message(message)
                 .build();

--- a/src/main/resources/com/banklab/risk/mapper/ProductRiskRatingMapper.xml
+++ b/src/main/resources/com/banklab/risk/mapper/ProductRiskRatingMapper.xml
@@ -6,9 +6,9 @@
     <!-- ResultMap 정의 -->
     <resultMap id="productRiskRatingMap" type="com.banklab.risk.domain.ProductRiskRating">
         <id property="id" column="id"/>
-        <result property="productType" column="product_type" typeHandler="org.apache.ibatis.type.EnumTypeHandler"/>
+        <result property="productType" column="product_type"  typeHandler="com.banklab.product.handler.ProductTypeHandler"/>
         <result property="productId" column="product_id"/>
-        <result property="riskLevel" column="risk_level" typeHandler="org.apache.ibatis.type.EnumTypeHandler"/>
+        <result property="riskLevel" column="risk_level" typeHandler="com.banklab.risk.handler.RiskLevelHandler"/>
         <result property="riskReason" column="risk_reason"/>
         <result property="evaluatedAt" column="evaluated_at"/>
         <result property="productName" column="product_name"/>

--- a/src/main/resources/com/banklab/typetest/mapper/InvestmentTypeMapper.xml
+++ b/src/main/resources/com/banklab/typetest/mapper/InvestmentTypeMapper.xml
@@ -4,6 +4,7 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.banklab.typetest.mapper.InvestmentTypeMapper">
+    <!-- id로 InvestmentType 조회 -->
     <select id="findById" resultType="com.banklab.typetest.domain.InvestmentType">
         SELECT id, investment_type_name AS investmentTypeName, investment_type_desc AS investmentTypeDesc
         FROM investment_type

--- a/src/main/resources/com/banklab/typetest/mapper/QuestionChoiceScoreMapper.xml
+++ b/src/main/resources/com/banklab/typetest/mapper/QuestionChoiceScoreMapper.xml
@@ -4,6 +4,11 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.banklab.typetest.mapper.QuestionChoiceScoreMapper">
+    <!--
+     질문 ID와 선택지를 기준으로 QuestionChoiceScore 엔티티를 조회하는 쿼리
+     파라미터: questionId, choice
+     반환 타입: com.banklab.typetest.domain.QuestionChoiceScore
+ -->
     <select id="findByQuestionIdAndChoice" resultType="com.banklab.typetest.domain.QuestionChoiceScore">
         SELECT
             id,

--- a/src/main/resources/com/banklab/typetest/mapper/QuestionMapper.xml
+++ b/src/main/resources/com/banklab/typetest/mapper/QuestionMapper.xml
@@ -4,6 +4,7 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.banklab.typetest.mapper.QuestionMapper">
+    <!-- 모든 질문을 조회하는 쿼리 -->
     <select id="getAllQuestions" resultType="com.banklab.typetest.domain.Question">
         SELECT
             id,
@@ -17,6 +18,7 @@
     </select>
     
     <select id="findById" resultType="com.banklab.typetest.domain.Question">
+        <!-- id로 질문을 조회하는 쿼리 -->
         SELECT
             id,
             question_text AS questionText,

--- a/src/main/resources/com/banklab/typetest/mapper/QuestionMapper.xml
+++ b/src/main/resources/com/banklab/typetest/mapper/QuestionMapper.xml
@@ -9,8 +9,23 @@
             id,
             question_text AS questionText,
             choice_a_text AS choiceAText,
-            choice_b_text AS choiceBText
+            choice_b_text AS choiceBText,
+            question_type AS questionType,
+            is_blocking AS isBlocking
         FROM question
+        ORDER BY id
+    </select>
+    
+    <select id="findById" resultType="com.banklab.typetest.domain.Question">
+        SELECT
+            id,
+            question_text AS questionText,
+            choice_a_text AS choiceAText,
+            choice_b_text AS choiceBText,
+            question_type AS questionType,
+            is_blocking AS isBlocking
+        FROM question
+        WHERE id = #{id}
     </select>
 </mapper>
 

--- a/src/main/resources/com/banklab/typetest/mapper/UserInvestmentConstraintsMapper.xml
+++ b/src/main/resources/com/banklab/typetest/mapper/UserInvestmentConstraintsMapper.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.banklab.typetest.mapper.UserInvestmentConstraintsMapper">
+    
+    <select id="findActiveConstraintsByUserId" resultType="com.banklab.typetest.domain.UserInvestmentConstraints">
+        SELECT
+            id,
+            user_id AS userId,
+            constraint_type AS constraintType,
+            is_active AS isActive
+        FROM user_investment_constraints
+        WHERE user_id = #{userId} AND is_active = true
+    </select>
+    
+    <insert id="insertUserInvestmentConstraints" parameterType="com.banklab.typetest.domain.UserInvestmentConstraints">
+        INSERT INTO user_investment_constraints (
+            user_id,
+            constraint_type,
+            is_active
+        ) VALUES (
+            #{userId},
+            #{constraintType},
+            #{isActive}
+        )
+    </insert>
+    
+    <update id="deactivateAllConstraints">
+        UPDATE user_investment_constraints
+        SET is_active = false
+        WHERE user_id = #{userId}
+    </update>
+    
+</mapper>

--- a/src/main/resources/com/banklab/typetest/mapper/UserInvestmentConstraintsMapper.xml
+++ b/src/main/resources/com/banklab/typetest/mapper/UserInvestmentConstraintsMapper.xml
@@ -17,6 +17,7 @@
         FROM user_investment_constraints
         WHERE user_id = #{userId} AND is_active = true
     </select>
+    
     <!--
         새로운 투자 제약 조건을 추가하는 INSERT 쿼리
         파라미터 타입: com.banklab.typetest.domain.UserInvestmentConstraints
@@ -32,6 +33,7 @@
             #{isActive}
         )
     </insert>
+    
     <!--
         특정 사용자의 모든 투자 제약 조건을 비활성화하는 UPDATE 쿼리
         사용자의 투자 조건이 변경되거나 초기화되어야 할 때 기존의 모든 제약 조건을 비활성화하기 위해 사용
@@ -40,6 +42,24 @@
         UPDATE user_investment_constraints
         SET is_active = false
         WHERE user_id = #{userId}
+    </update>
+
+    <!-- 특정 사용자의 특정 제약조건 조회 -->
+    <select id="findByUserIdAndConstraintType" resultType="com.banklab.typetest.domain.UserInvestmentConstraints">
+        SELECT
+            id,
+            user_id AS userId,
+            constraint_type AS constraintType,
+            is_active AS isActive
+        FROM user_investment_constraints
+        WHERE user_id = #{userId} AND constraint_type = #{constraintType}
+    </select>
+
+    <!-- 특정 제약조건 활성화 -->
+    <update id="activateConstraint">
+        UPDATE user_investment_constraints
+        SET is_active = true
+        WHERE user_id = #{userId} AND constraint_type = #{constraintType}
     </update>
     
 </mapper>

--- a/src/main/resources/com/banklab/typetest/mapper/UserInvestmentConstraintsMapper.xml
+++ b/src/main/resources/com/banklab/typetest/mapper/UserInvestmentConstraintsMapper.xml
@@ -4,7 +4,10 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.banklab.typetest.mapper.UserInvestmentConstraintsMapper">
-    
+    <!--
+          사용자 ID로 활성화된 투자 제약 조건을 조회하는 SELECT 쿼리
+          반환 타입: com.banklab.typetest.domain.UserInvestmentConstraints
+      -->
     <select id="findActiveConstraintsByUserId" resultType="com.banklab.typetest.domain.UserInvestmentConstraints">
         SELECT
             id,
@@ -14,7 +17,10 @@
         FROM user_investment_constraints
         WHERE user_id = #{userId} AND is_active = true
     </select>
-    
+    <!--
+        새로운 투자 제약 조건을 추가하는 INSERT 쿼리
+        파라미터 타입: com.banklab.typetest.domain.UserInvestmentConstraints
+    -->
     <insert id="insertUserInvestmentConstraints" parameterType="com.banklab.typetest.domain.UserInvestmentConstraints">
         INSERT INTO user_investment_constraints (
             user_id,
@@ -26,7 +32,10 @@
             #{isActive}
         )
     </insert>
-    
+    <!--
+        특정 사용자의 모든 투자 제약 조건을 비활성화하는 UPDATE 쿼리
+        사용자의 투자 조건이 변경되거나 초기화되어야 할 때 기존의 모든 제약 조건을 비활성화하기 위해 사용
+    -->
     <update id="deactivateAllConstraints">
         UPDATE user_investment_constraints
         SET is_active = false

--- a/src/main/resources/com/banklab/typetest/mapper/UserInvestmentProfileMapper.xml
+++ b/src/main/resources/com/banklab/typetest/mapper/UserInvestmentProfileMapper.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.banklab.typetest.mapper.UserInvestmentProfileMapper">
+    
+    <select id="findByUserId" resultType="com.banklab.typetest.domain.UserInvestmentProfile">
+        SELECT
+            id,
+            user_id AS userId,
+            available_amount_range AS availableAmountRange,
+            target_return_range AS targetReturnRange,
+            investment_period_range AS investmentPeriodRange,
+            loss_tolerance_range AS lossToleranceRange,
+            investment_style AS investmentStyle,
+            priority
+        FROM user_investment_profile
+        WHERE user_id = #{userId}
+    </select>
+    
+    <insert id="insertUserInvestmentProfile" parameterType="com.banklab.typetest.domain.UserInvestmentProfile">
+        INSERT INTO user_investment_profile (
+            user_id,
+            available_amount_range,
+            target_return_range,
+            investment_period_range,
+            loss_tolerance_range,
+            investment_style,
+            priority
+        ) VALUES (
+            #{userId},
+            #{availableAmountRange},
+            #{targetReturnRange},
+            #{investmentPeriodRange},
+            #{lossToleranceRange},
+            #{investmentStyle},
+            #{priority}
+        )
+    </insert>
+    
+    <update id="updateUserInvestmentProfile" parameterType="com.banklab.typetest.domain.UserInvestmentProfile">
+        UPDATE user_investment_profile
+        SET
+            available_amount_range = #{availableAmountRange},
+            target_return_range = #{targetReturnRange},
+            investment_period_range = #{investmentPeriodRange},
+            loss_tolerance_range = #{lossToleranceRange},
+            investment_style = #{investmentStyle},
+            priority = #{priority}
+        WHERE user_id = #{userId}
+    </update>
+    
+</mapper>

--- a/src/main/resources/com/banklab/typetest/mapper/UserInvestmentProfileMapper.xml
+++ b/src/main/resources/com/banklab/typetest/mapper/UserInvestmentProfileMapper.xml
@@ -4,7 +4,11 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.banklab.typetest.mapper.UserInvestmentProfileMapper">
-    
+    <!--
+       사용자 ID로 투자 성향 프로필을 조회하는 SELECT 문
+       반환 타입: com.banklab.typetest.domain.UserInvestmentProfile
+       파라미터: userId
+   -->
     <select id="findByUserId" resultType="com.banklab.typetest.domain.UserInvestmentProfile">
         SELECT
             id,
@@ -18,7 +22,10 @@
         FROM user_investment_profile
         WHERE user_id = #{userId}
     </select>
-    
+    <!--
+      투자 성향 프로필을 추가하는 INSERT 문
+      파라미터 타입: com.banklab.typetest.domain.UserInvestmentProfile
+  -->
     <insert id="insertUserInvestmentProfile" parameterType="com.banklab.typetest.domain.UserInvestmentProfile">
         INSERT INTO user_investment_profile (
             user_id,
@@ -38,7 +45,11 @@
             #{priority}
         )
     </insert>
-    
+    <!--
+    투자 성향 프로필을 수정하는 UPDATE 문
+    파라미터 타입: com.banklab.typetest.domain.UserInvestmentProfile
+    user_id로 해당 프로필을 찾아 업데이트
+-->
     <update id="updateUserInvestmentProfile" parameterType="com.banklab.typetest.domain.UserInvestmentProfile">
         UPDATE user_investment_profile
         SET

--- a/src/main/resources/com/banklab/typetest/mapper/UserInvestmentTypeMapper.xml
+++ b/src/main/resources/com/banklab/typetest/mapper/UserInvestmentTypeMapper.xml
@@ -4,21 +4,25 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.banklab.typetest.mapper.UserInvestmentTypeMapper">
+    <!-- userId로 UserInvestmentType 조회 (최대 1건) -->
     <select id="findByUserId" resultType="com.banklab.typetest.domain.UserInvestmentType">
         SELECT * FROM user_investment_type
         WHERE user_id = #{userId}
         LIMIT 1
     </select>
+    <!-- userId와 evaluationDate로 UserInvestmentType 조회 -->
     <select id="findByUserIdAndDate" resultType="com.banklab.typetest.domain.UserInvestmentType">
         SELECT *
         FROM user_investment_type
         WHERE user_id = #{userId}
           AND evaluation_date = #{evaluationDate}
     </select>
+    <!-- UserInvestmentType 데이터 삽입 -->
     <insert id="insertUserInvestmentType" parameterType="com.banklab.typetest.domain.UserInvestmentType">
         INSERT INTO user_investment_type (user_id, investment_type_id, evaluation_date)
         VALUES (#{userId}, #{investmentTypeId}, #{evaluationDate})
     </insert>
+    <!-- UserInvestmentType 데이터 수정 -->
     <update id="updateUserInvestmentType" parameterType="com.banklab.typetest.domain.UserInvestmentType">
         UPDATE user_investment_type
         SET investment_type_id = #{investmentTypeId}, evaluation_date = #{evaluationDate}

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -17,5 +17,11 @@
                      javaType="com.banklab.member.domain.Gender"/>
         <typeHandler handler="com.banklab.oauth.handler.OAuthProviderTypeHandler"
                     javaType="com.banklab.oauth.domain.OAuthProvider"/>
+        <typeHandler handler="com.banklab.product.handler.ProductTypeHandler"
+                     javaType="com.banklab.product.domain.ProductType"/>
+        <typeHandler handler="com.banklab.risk.handler.RiskLevelHandler"
+                     javaType="com.banklab.risk.domain.RiskLevel"/>
+
+
     </typeHandlers>
 </configuration>

--- a/src/test/java/com/banklab/typetest/controller/ProductRecommendationControllerTest.java
+++ b/src/test/java/com/banklab/typetest/controller/ProductRecommendationControllerTest.java
@@ -47,11 +47,10 @@ class ProductRecommendationControllerTest {
         List<RecommendedProductDTO> expectedProducts = Arrays.asList(
                 RecommendedProductDTO.builder()
                         .productId(1L)
-                        .productName("안전한 정기예금")
                         .productType(ProductType.DEPOSIT)
+                        .productName("안전한 정기예금")
                         .riskLevel(RiskLevel.LOW)
                         .interestRate("연 2.5%")
-                        .productFeature("원금 보장되는 안전한 상품입니다.")
                         .build()
         );
 
@@ -78,11 +77,10 @@ class ProductRecommendationControllerTest {
         List<RecommendedProductDTO> expectedProducts = Arrays.asList(
                 RecommendedProductDTO.builder()
                         .productId(3L)
-                        .productName("혼합형 펀드")
+                        .productName("적금")
                         .productType(ProductType.SAVINGS)
                         .riskLevel(RiskLevel.MEDIUM)
                         .interestRate("연 5.0%")
-                        .productFeature("주식과 채권을 균형있게 투자하는 펀드입니다.")
                         .build()
         );
 
@@ -94,7 +92,7 @@ class ProductRecommendationControllerTest {
 
         // Then
         assertEquals(1, actualProducts.size());
-        assertEquals("혼합형 펀드", actualProducts.get(0).getProductName());
+        assertEquals("적금", actualProducts.get(0).getProductName());
         assertEquals(RiskLevel.MEDIUM, actualProducts.get(0).getRiskLevel());
         assertEquals(ProductType.SAVINGS, actualProducts.get(0).getProductType());
 
@@ -109,11 +107,10 @@ class ProductRecommendationControllerTest {
         List<RecommendedProductDTO> expectedProducts = Arrays.asList(
                 RecommendedProductDTO.builder()
                         .productId(5L)
-                        .productName("성장형 주식펀드")
+                        .productName("신용대출")
                         .productType(ProductType.LOAN)
                         .riskLevel(RiskLevel.HIGH)
                         .interestRate("연 10.0%")
-                        .productFeature("고성장 기업에 투자하는 펀드입니다.")
                         .build()
         );
 
@@ -125,7 +122,7 @@ class ProductRecommendationControllerTest {
 
         // Then
         assertEquals(1, actualProducts.size());
-        assertEquals("성장형 주식펀드", actualProducts.get(0).getProductName());
+        assertEquals("신용대출", actualProducts.get(0).getProductName());
         assertEquals(RiskLevel.HIGH, actualProducts.get(0).getRiskLevel());
         assertEquals(ProductType.LOAN, actualProducts.get(0).getProductType());
 

--- a/src/test/java/com/banklab/typetest/controller/TypeTestControllerTest.java
+++ b/src/test/java/com/banklab/typetest/controller/TypeTestControllerTest.java
@@ -70,37 +70,28 @@ class TypeTestControllerTest {
     }
 
     @Test
-    @DisplayName("사용자가 유형검사를 제출했을 때 결과가 잘 뜨는지")
-    void 사용자가_유형검사를_제출했을_때_결과가_잘_뜨는지() {
+    @DisplayName("사용자가 유형검사를 제출했을 때 OK 메시지가 잘 뜨는지")
+    void 사용자가_유형검사를_제출했을_때_OK_메시지가_잘_뜨는지() {
         // Given
         String mockToken = "valid-jwt-token";
         Long memberId = 1L;
-        
+
         Map<String, Object> payload = new HashMap<>();
         payload.put("answers", Arrays.asList(1, 2, 3, 1, 2));
-        
-        TypeTestResultDTO expectedResult = TypeTestResultDTO.builder()
-                .investmentTypeId(2L)
-                .investmentTypeName("중립형")
-                .investmentTypeDesc("적당한 위험을 감수하며 안정적인 수익을 추구합니다.")
-                .build();
 
         try (MockedStatic<JwtTokenUtil> mockedJwtTokenUtil = mockStatic(JwtTokenUtil.class)) {
             mockedJwtTokenUtil.when(() -> JwtTokenUtil.extractToken(any(HttpServletRequest.class)))
                     .thenReturn(mockToken);
-            
+
             when(jwtProcessor.getMemberId(mockToken)).thenReturn(memberId);
-            when(typeTestService.submitAnswersWithMemberId(eq(payload), eq(memberId)))
-                    .thenReturn(expectedResult);
 
             // When
-            ResponseEntity<TypeTestResultDTO> response = typeTestController.submitAnswers(httpServletRequest, payload);
+            ResponseEntity<Map<String, String>> response = typeTestController.submitAnswers(httpServletRequest, payload);
 
             // Then
             assertEquals(200, response.getStatusCodeValue());
             assertNotNull(response.getBody());
-            assertEquals(Long.valueOf(2L), response.getBody().getInvestmentTypeId());
-            assertEquals("중립형", response.getBody().getInvestmentTypeName());
+            assertEquals("OK", response.getBody().get("message"));
 
             verify(jwtProcessor).getMemberId(mockToken);
             verify(typeTestService).submitAnswersWithMemberId(any(Map.class), eq(memberId));
@@ -123,12 +114,12 @@ class TypeTestControllerTest {
             when(jwtProcessor.getMemberId(invalidToken)).thenReturn(null);
 
             // When
-            ResponseEntity<TypeTestResultDTO> response = typeTestController.submitAnswers(httpServletRequest, payload);
+            ResponseEntity<Map<String, String>> response = typeTestController.submitAnswers(httpServletRequest, payload);
 
             // Then
             assertEquals(400, response.getStatusCodeValue());
             assertNotNull(response.getBody());
-            assertEquals("유효하지 않은 토큰입니다.", response.getBody().getMessage());
+            assertEquals("유효하지 않은 토큰입니다.", response.getBody().get("message"));
 
             verify(jwtProcessor).getMemberId(invalidToken);
             verify(typeTestService, never()).submitAnswersWithMemberId(any(), any());
@@ -261,12 +252,12 @@ class TypeTestControllerTest {
             when(jwtProcessor.getMemberId(token)).thenReturn(null);
 
             // When
-            ResponseEntity<TypeTestResultDTO> response = typeTestController.submitAnswers(httpServletRequest, payload);
+            ResponseEntity<Map<String, String>> response = typeTestController.submitAnswers(httpServletRequest, payload);
 
             // Then
             assertEquals(400, response.getStatusCodeValue());
             assertNotNull(response.getBody());
-            assertEquals("유효하지 않은 토큰입니다.", response.getBody().getMessage());
+            assertEquals("유효하지 않은 토큰입니다.", response.getBody().get("message"));
 
             verify(jwtProcessor).getMemberId(token);
             verify(typeTestService, never()).submitAnswersWithMemberId(any(), any());

--- a/src/test/java/com/banklab/typetest/service/ProductRecommendationServiceTest.java
+++ b/src/test/java/com/banklab/typetest/service/ProductRecommendationServiceTest.java
@@ -40,14 +40,12 @@ class ProductRecommendationServiceTest {
                         .productName("안전한 정기예금")
                         .riskLevel(RiskLevel.LOW)
                         .interestRate("연 2.5%")
-                        .productFeature("원금 보장되는 안전한 상품입니다.")
                         .build(),
                 RecommendedProductDTO.builder()
                         .productId(2L)
-                        .productName("국채형 펀드")
+                        .productName("안전한 적금")
                         .riskLevel(RiskLevel.LOW)
                         .interestRate("연 3.0%")
-                        .productFeature("국채 중심의 안전한 펀드입니다.")
                         .build()
         );
 
@@ -61,7 +59,7 @@ class ProductRecommendationServiceTest {
         assertEquals(2, actualProducts.size());
         assertEquals("안전한 정기예금", actualProducts.get(0).getProductName());
         assertEquals(RiskLevel.LOW, actualProducts.get(0).getRiskLevel());
-        assertEquals("국채형 펀드", actualProducts.get(1).getProductName());
+        assertEquals("안전한 적금", actualProducts.get(1).getProductName());
         assertEquals(RiskLevel.LOW, actualProducts.get(1).getRiskLevel());
     }
 
@@ -74,17 +72,15 @@ class ProductRecommendationServiceTest {
         List<RecommendedProductDTO> expectedProducts = Arrays.asList(
                 RecommendedProductDTO.builder()
                         .productId(3L)
-                        .productName("혼합형 펀드")
+                        .productName("복잡한 적금")
                         .riskLevel(RiskLevel.MEDIUM)
                         .interestRate("연 5.0%")
-                        .productFeature("주식과 채권을 균형있게 투자하는 펀드입니다.")
                         .build(),
                 RecommendedProductDTO.builder()
                         .productId(4L)
-                        .productName("인덱스 펀드")
+                        .productName("복잡한 예금")
                         .riskLevel(RiskLevel.MEDIUM)
                         .interestRate("연 6.0%")
-                        .productFeature("시장 지수를 따라가는 안정적인 펀드입니다.")
                         .build()
         );
 
@@ -96,9 +92,9 @@ class ProductRecommendationServiceTest {
 
         // Then
         assertEquals(2, actualProducts.size());
-        assertEquals("혼합형 펀드", actualProducts.get(0).getProductName());
+        assertEquals("복잡한 적금", actualProducts.get(0).getProductName());
         assertEquals(RiskLevel.MEDIUM, actualProducts.get(0).getRiskLevel());
-        assertEquals("인덱스 펀드", actualProducts.get(1).getProductName());
+        assertEquals("복잡한 예금", actualProducts.get(1).getProductName());
         assertEquals(RiskLevel.MEDIUM, actualProducts.get(1).getRiskLevel());
     }
 
@@ -111,17 +107,15 @@ class ProductRecommendationServiceTest {
         List<RecommendedProductDTO> expectedProducts = Arrays.asList(
                 RecommendedProductDTO.builder()
                         .productId(5L)
-                        .productName("성장형 주식펀드")
+                        .productName("개인 신용대출1")
                         .riskLevel(RiskLevel.HIGH)
                         .interestRate("연 10.0%")
-                        .productFeature("고성장 기업에 투자하는 펀드입니다.")
                         .build(),
                 RecommendedProductDTO.builder()
                         .productId(6L)
-                        .productName("해외 신흥국 펀드")
+                        .productName("개인 신용대출2")
                         .riskLevel(RiskLevel.HIGH)
                         .interestRate("연 12.0%")
-                        .productFeature("신흥국 시장에 투자하는 고수익 펀드입니다.")
                         .build()
         );
 
@@ -133,9 +127,9 @@ class ProductRecommendationServiceTest {
 
         // Then
         assertEquals(2, actualProducts.size());
-        assertEquals("성장형 주식펀드", actualProducts.get(0).getProductName());
+        assertEquals("개인 신용대출1", actualProducts.get(0).getProductName());
         assertEquals(RiskLevel.HIGH, actualProducts.get(0).getRiskLevel());
-        assertEquals("해외 신흥국 펀드", actualProducts.get(1).getProductName());
+        assertEquals("개인 신용대출2", actualProducts.get(1).getProductName());
         assertEquals(RiskLevel.HIGH, actualProducts.get(1).getRiskLevel());
     }
 


### PR DESCRIPTION
### [BNK-109] 유형검사에 따른 결과 제한 및 상품 추천 고도화

## 개요

- 사용자 투자유형 제한, 상품 추천 고도화를 위해 질문지 내용 및, 데이터베이스 구조를 수정하였습니다(노션 sql페이지에 typetest2.sql로 수정 쿼리 올려놨습니다)
- 사용자 유형검사에 따른 투자 유형 제한 (ex: 고위험상품 금지 -> 안정형/중립형으로 제한)
- 사용자 맞춤형 AI 상품 추천 기능 구현
  - 사용자 결과 화면에서는 AI 맞춤 추천 상품 4개, 전체 목록에서는 투자 유형에 맞는 상품 목록이 표시됩니다.

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [X] 코드 리팩토링
- [ ] 코드에 영향 없는 수정
- [ ] 문서 수정
- [X] 테스트 추가/리팩토링
- [ ] 빌드/패키지 관련
- [ ] 파일/폴더명 수정
- [ ] 파일 삭제

## PR Checklist

- [X] 1. 커밋 메시지 컨벤션을 지켰나요?
- [X] 2. 기능 테스트를 완료했나요?
- [ ] 3-1. main 브랜치로 머지 요청했나요?
- [X] 3-2. Develop 브랜치로 머지 요청했나요?

## 테스트 결과 (캡쳐이미지)


[BNK-109]: https://banklab00.atlassian.net/browse/BNK-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ