### PR TITLE
[BNK-230] Fix : 계좌 연동시 외환, 펀드, 보험 계좌 연동 데이터 응답 구조 추가

### DIFF
--- a/src/main/java/com/banklab/account/controller/AccountController.java
+++ b/src/main/java/com/banklab/account/controller/AccountController.java
@@ -3,6 +3,7 @@ package com.banklab.account.controller;
 import com.banklab.account.domain.AccountVO;
 import com.banklab.account.dto.AccountDTO;
 import com.banklab.account.dto.AccountRequestDTO;
+import com.banklab.account.dto.AccountManageRequestDTO;
 import com.banklab.account.service.AccountResponse;
 import com.banklab.account.service.AccountService;
 import com.banklab.codef.service.RequestConnectedId;
@@ -22,7 +23,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
 import java.time.LocalDate;
 import java.util.Date;
 import java.util.HashMap;
@@ -182,7 +182,7 @@ public class AccountController {
     @PutMapping("/refresh")
     @ApiOperation(value = "계좌 잔액 새로고침", notes = "커넥티드 아이디로 계좌 잔액을 새로고침.")
     public ResponseEntity<Map<String, Object>> refreshAccountBalance(
-            @RequestBody AccountRequestDTO accountRequest
+            @RequestBody AccountManageRequestDTO request
     ) {
         try {
             Map<String, Object> authInfo = extractAuthInfo();
@@ -190,16 +190,16 @@ public class AccountController {
             String email = (String) authInfo.get("email");
 
             log.info("계좌 잔액 새로고침 - email: {}, memberId: {}, bankCode: {}",
-                    email, memberId, accountRequest.getBankCode());
+                    email, memberId, request.getBankCode());
 
             // 권한 검증
-            if (!accountService.isConnectedIdOwner(memberId, accountRequest.getConnectedId())) {
+            if (!accountService.isConnectedIdOwner(memberId, request.getConnectedId())) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN)
                         .body(createErrorResponse("해당 계좌에 대한 권한이 없습니다.", "UNAUTHORIZED_ACCESS"));
             }
 
             // 잔액 새로고침
-            accountService.refreshAccountBalance(memberId, accountRequest.getBankCode(), accountRequest.getConnectedId());
+            accountService.refreshAccountBalance(memberId, request.getBankCode(), request.getConnectedId());
             List<AccountDTO> accountList = accountService.getUserAccounts(memberId);
 
             Map<String, Object> response = new HashMap<>();
@@ -225,8 +225,7 @@ public class AccountController {
     @DeleteMapping("/unlink")
     @ApiOperation(value = "계좌 연동 해제", notes = "로그인한 사용자의 커넥티드 아이디를 삭제하고 계좌 연동을 해제.")
     public ResponseEntity<Map<String, Object>> unlinkAccount(
-            HttpServletRequest request,
-            @RequestBody AccountRequestDTO accountRequest
+            @RequestBody AccountManageRequestDTO request
     ) {
         try {
             Map<String, Object> authInfo = extractAuthInfo();
@@ -234,24 +233,24 @@ public class AccountController {
             String email = (String) authInfo.get("email");
 
             log.info("계좌 연동 해제 - email: {}, memberId: {}, bankCode: {}",
-                    email, memberId, accountRequest.getBankCode());
+                    email, memberId, request.getBankCode());
 
             // 권한 검증
-            if (!accountService.isConnectedIdOwner(memberId, accountRequest.getConnectedId())) {
+            if (!accountService.isConnectedIdOwner(memberId, request.getConnectedId())) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN)
                         .body(createErrorResponse("해당 계좌에 대한 권한이 없습니다.", "UNAUTHORIZED_ACCESS"));
             }
 
             // 연동 해제
             boolean deleted = RequestConnectedId.deleteConnectedId(
-                    accountRequest.getConnectedId(),
-                    accountRequest.getBankCode(),
+                    request.getConnectedId(),
+                    request.getBankCode(),
                     "BK",
                     "P"
             );
 
             if (deleted) {
-                accountService.deleteAccount(memberId, accountRequest.getConnectedId());
+                accountService.deleteAccount(memberId, request.getConnectedId());
                 return ResponseEntity.ok(createSuccessResponse("계좌 연동 해제가 완료되었습니다.", null, authInfo));
             } else {
                 return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -276,7 +275,6 @@ public class AccountController {
     @GetMapping("/{accountId}/transactions")
     @ApiOperation(value = "계좌 거래내역 상세 조회", notes = "특정 계좌의 기간별 거래내역 상세 정보를 조회합니다.")
     public ResponseEntity<Map<String, Object>> getAccountTransactions(
-            HttpServletRequest request,
             @PathVariable Long accountId,
             @RequestParam(value = "start", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Date startDate,
             @RequestParam(value = "end", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Date endDate

--- a/src/main/java/com/banklab/account/dto/AccountManageRequestDTO.java
+++ b/src/main/java/com/banklab/account/dto/AccountManageRequestDTO.java
@@ -1,0 +1,18 @@
+package com.banklab.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 자산 새로고침, 삭제 요청 DTO
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AccountManageRequestDTO {
+
+    private String bankCode;    // 기관코드
+    private String connectedId;     // 커넥티드 아이디
+
+}

--- a/src/main/java/com/banklab/account/dto/AccountRequestDTO.java
+++ b/src/main/java/com/banklab/account/dto/AccountRequestDTO.java
@@ -13,8 +13,5 @@ public class AccountRequestDTO {
     private String bankCode;
     private String bankId;
     private String bankPassword;
-
-    // 잔액 새로고침, 연동 해제 시 사용
-    private String connectedId;
     
 }

--- a/src/main/java/com/banklab/stock/controller/StockApiController.java
+++ b/src/main/java/com/banklab/stock/controller/StockApiController.java
@@ -4,6 +4,7 @@ import com.banklab.codef.service.RequestConnectedId;
 import com.banklab.common.redis.RedisService;
 import com.banklab.security.util.LoginUserProvider;
 import com.banklab.stock.domain.StockVO;
+import com.banklab.stock.dto.StockManageRequestDTO;
 import com.banklab.stock.dto.StockRequestDTO;
 import com.banklab.stock.service.StockResponse;
 import com.banklab.stock.service.StockService;
@@ -164,7 +165,7 @@ public class StockApiController {
     @PutMapping("/refresh")
     @ApiOperation(value = "보유종목 정보 새로고침", notes = "커넥티드 아이디로 보유종목 정보를 새로고침.")
     public ResponseEntity<Map<String, Object>> refreshUserStocks(
-            @RequestBody StockRequestDTO stockRequest
+            @RequestBody StockManageRequestDTO request
     ) {
         try {
             Map<String, Object> authInfo = extractAuthInfo();
@@ -172,14 +173,14 @@ public class StockApiController {
             String email = (String) authInfo.get("email");
 
             log.info("보유종목 정보 새로고침 - email: {}, memberId: {}, stockCode: {}",
-                    email, memberId, stockRequest.getStockCode());
+                    email, memberId, request.getStockCode());
 
             // 보유종목 새로고침
             stockService.refreshUserStocks(
                     memberId,
-                    stockRequest.getStockCode(),
-                    stockRequest.getConnectedId(),
-                    stockRequest.getAccount()
+                    request.getStockCode(),
+                    request.getConnectedId(),
+                    request.getAccount()
             );
 
             List<StockVO> stockList = stockService.getUserStocks(memberId);
@@ -207,7 +208,7 @@ public class StockApiController {
     @DeleteMapping("/unlink")
     @ApiOperation(value = "증권계좌 연동 해제", notes = "로그인한 사용자의 커넥티드 아이디를 삭제하고 증권계좌 연동을 해제.")
     public ResponseEntity<Map<String, Object>> unlinkStock(
-            @RequestBody StockRequestDTO stockRequest
+            @RequestBody StockManageRequestDTO request
     ) {
         try {
             Map<String, Object> authInfo = extractAuthInfo();
@@ -215,18 +216,18 @@ public class StockApiController {
             String email = (String) authInfo.get("email");
 
             log.info("증권계좌 연동 해제 - email: {}, memberId: {}, stockCode: {}, account: {}",
-                    email, memberId, stockRequest.getStockCode(), stockRequest.getAccount());
+                    email, memberId, request.getStockCode(), request.getAccount());
 
             // 연동 해제
             boolean deleted = RequestConnectedId.deleteConnectedId(
-                    stockRequest.getConnectedId(),
-                    stockRequest.getStockCode(),
+                    request.getConnectedId(),
+                    request.getStockCode(),
                     "ST",
                     "A"
             );
 
             if (deleted) {
-                stockService.disconnectUserStocks(memberId, stockRequest.getConnectedId());
+                stockService.disconnectUserStocks(memberId, request.getConnectedId());
                 return ResponseEntity.ok(createSuccessResponse("증권계좌 연동 해제가 완료되었습니다.", null, authInfo));
             } else {
                 return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/banklab/stock/dto/StockManageRequestDTO.java
+++ b/src/main/java/com/banklab/stock/dto/StockManageRequestDTO.java
@@ -1,0 +1,14 @@
+package com.banklab.stock.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class StockManageRequestDTO {
+    private String account;
+    private String connectedId;
+    private String stockCode;
+}

--- a/src/test/java/com/banklab/account/service/AccountResponseTest.java
+++ b/src/test/java/com/banklab/account/service/AccountResponseTest.java
@@ -1,5 +1,7 @@
 package com.banklab.account.service;
 
+import com.banklab.codef.util.CommonConstant;
+import com.banklab.config.MailConfig;
 import com.banklab.config.RedisConfig;
 import com.banklab.config.RootConfig;
 import com.banklab.security.config.SecurityConfig;
@@ -19,12 +21,12 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 @ExtendWith(SpringExtension.class)
 @Log4j2
-@ContextConfiguration(classes = {RootConfig.class, SecurityConfig.class, RedisConfig.class})
+@ContextConfiguration(classes = {RootConfig.class, SecurityConfig.class, RedisConfig.class, CommonConstant.class, MailConfig.class})
 class AccountResponseTest {
 
     @Test
     void 계좌_연동_테스트() throws Exception {
-        String connectedId = "발급된 커넥티드 아이디";
+        String connectedId = "4SiQcG3zAjuagbVaeRyH8d";
 
         requestAccounts(1L,"0004", connectedId);
     }


### PR DESCRIPTION
### [BNK-230] Fix : 계좌 연동시 외환, 펀드, 보험 계좌 연동 데이터 응답 구조 추가

## 개요

- 기존에 예금, 적금 계좌만 데이터 저장하던 로직 수정
- 외환, 펀드, 보험 계좌 테이블에 추가할 수 있도록 응답 구조 수정
- AccountResponse만 수정

## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 코드에 영향 없는 수정
- [ ] 문서 수정
- [ ] 테스트 추가/리팩토링
- [ ] 빌드/패키지 관련
- [ ] 파일/폴더명 수정
- [ ] 파일 삭제

## PR Checklist

- [ ] 1. 커밋 메시지 컨벤션을 지켰나요?
- [ ] 2. 기능 테스트를 완료했나요?
- [ ] 3-1. main 브랜치로 머지 요청했나요?
- [ ] 3-2. develop 브랜치로 머지 요청했나요?

## 테스트 결과 (캡쳐이
<img width="836" height="680" alt="스크린샷 2025-08-07 오후 3 32 45" src="https://github.com/user-attachments/assets/d9e0bbe8-2a36-41e7-aab3-683ca5f21d99" />
<img width="856" height="476" alt="스크린샷 2025-08-07 오후 3 32 57" src="https://github.com/user-attachments/assets/722932b1-62a8-4fdc-aaf1-4c71df96da2c" />
미지)

