### PR TITLE
[BNK-267] Feat : 보유종목 단일항목 보기 API 개발

### DIFF
--- a/src/main/java/com/banklab/financeContents/controller/StockController.java
+++ b/src/main/java/com/banklab/financeContents/controller/StockController.java
@@ -49,7 +49,7 @@ public class StockController {
             LocalDate yesterday = LocalDate.now().minusDays(1); // 전일 데이터
             log.info("📅 저장 대상 날짜: {} (어제)", yesterday);
             
-            int savedCount = financeStockService.saveTopStockDataFromApi(yesterday, 200);
+            int savedCount = financeStockService.saveTopStockDataFromApi(yesterday, 1000);
             
             Map<String, Object> result = createSuccessResponseMap("오늘자 주식 데이터 저장 완료", null);
             result.put("date", yesterday.toString());
@@ -77,7 +77,7 @@ public class StockController {
             log.info("🗑️ 30일 이전 오래된 데이터 {}건 삭제", deletedCount);
             
             // 최근 30일 데이터 저장
-            int savedCount = financeStockService.saveRecentStockData(30, 200);
+            int savedCount = financeStockService.saveRecentStockData(30, 1000);
             
             Map<String, Object> result = createSuccessResponseMap("최근 30일 데이터 저장 완료", null);
             result.put("savedCount", savedCount);
@@ -95,7 +95,7 @@ public class StockController {
         }
     }
 
-    @PostMapping("/save/code/{stockCode}")
+    @PostMapping("/save/{stockCode}")
     @ApiOperation(value = "종목코드 기준으로 최근 30일간 데이터 저장")
     public ResponseEntity<Map<String, Object>> saveStockDataByCode(
             @ApiParam(value = "종목코드 (6자리)", example = "005930") 
@@ -454,11 +454,11 @@ public class StockController {
         }
     }
 
-    @GetMapping("/timeseries/code")
+    @GetMapping("/timeseries/{code}")
     @ApiOperation(value = "종목코드로 시계열 데이터 조회 (기준일자별 정렬)")
     public ResponseEntity<Map<String, Object>> getStockTimeSeriesByCode(
             @ApiParam(value = "검색할 종목코드 (6자리)", example = "005930") 
-            @RequestParam String code,
+            @PathVariable String code,
             @ApiParam(value = "조회할 개수 (기본값: 30)", example = "30") 
             @RequestParam(required = false, defaultValue = "30") Integer limit) {
         try {

--- a/src/main/java/com/banklab/stock/controller/StockApiController.java
+++ b/src/main/java/com/banklab/stock/controller/StockApiController.java
@@ -246,4 +246,80 @@ public class StockApiController {
         }
     }
 
+
+    /**
+     * 보유종목 상세정보 조회 (시계열 데이터 포함)
+     */
+    @GetMapping("/{stockId}/detail")
+    @ApiOperation(value = "보유종목 상세정보 조회", notes = "보유종목 ID로 기본정보와 시계열 데이터를 조회합니다.")
+    public ResponseEntity<Map<String, Object>> getStockDetail(
+            @PathVariable Long stockId,
+            @RequestParam(required = false, defaultValue = "30") Integer limit
+    ) {
+        try {
+            Map<String, Object> authInfo = extractAuthInfo();
+            Long memberId = (Long) authInfo.get("memberId");
+            String email = (String) authInfo.get("email");
+
+            log.info("보유종목 상세정보 조회 - email: {}, memberId: {}, stockId: {}",
+                    email, memberId, stockId);
+
+            // 1. 보유종목 기본정보 조회
+            StockVO stockInfo = stockService.getStockById(stockId, memberId);
+            if (stockInfo == null) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(createErrorResponse("보유종목을 찾을 수 없습니다.", "STOCK_NOT_FOUND"));
+            }
+
+            // 2. 종목코드 가져오기 (이미 A가 제거된 6자리 코드)
+            String resItemCode = stockInfo.getResItemCode();
+
+            log.info("종목코드: {}", resItemCode);
+
+            // 3. 종목코드로 시계열 데이터 조회 (내부 API 호출)
+            List<Map<String, Object>> timeSeriesData = null;
+            try {
+                if (resItemCode != null && resItemCode.length() == 6) {
+                    timeSeriesData = stockService.getTimeSeriesDataByCode(resItemCode, limit);
+                }
+            } catch (Exception e) {
+                log.warn("시계열 데이터 조회 실패 - resItemCode: {}, error: {}", resItemCode, e.getMessage());
+                // 시계열 데이터 조회 실패해도 기본 정보는 반환
+            }
+
+            // 4. 응답 데이터 구성
+            Map<String, Object> response = new HashMap<>();
+
+            // 보유종목 기본정보
+            Map<String, Object> stockDetail = new HashMap<>();
+            stockDetail.put("id", stockInfo.getId());
+            stockDetail.put("resItemName", stockInfo.getResItemName());
+            stockDetail.put("resItemCode", stockInfo.getResItemCode());
+            stockDetail.put("quantity", stockInfo.getResQuantity());
+            stockDetail.put("presentAmt", stockInfo.getResPresentAmt());
+            stockDetail.put("purchaseAmount", stockInfo.getResPurchaseAmount());
+            stockDetail.put("valuationAmt", stockInfo.getResValuationAmt());
+            stockDetail.put("valuationPL", stockInfo.getResValuationPL());
+            stockDetail.put("earningsRate", stockInfo.getResEarningsRate());
+            stockDetail.put("accountCurrency", stockInfo.getResAccountCurrency());
+            stockDetail.put("productType", stockInfo.getResProductType());
+
+            response.put("stockInfo", stockDetail);
+            response.put("timeSeriesData", timeSeriesData);
+            response.put("timeSeriesCount", timeSeriesData != null ? timeSeriesData.size() : 0);
+            response.put("timeSeriesLimit", limit);
+
+            return ResponseEntity.ok(createSuccessResponse("보유종목 상세정보 조회 완료", response, authInfo));
+
+        } catch (SecurityException e) {
+            log.error("인증 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(createErrorResponse(e.getMessage(), "AUTHENTICATION_ERROR"));
+
+        } catch (Exception e) {
+            log.error("보유종목 상세정보 조회 중 오류 발생 - stockId: {}", stockId, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(createErrorResponse("보유종목 상세정보 조회 중 오류가 발생했습니다.", "INTERNAL_ERROR"));
+        }
+    }
 }

--- a/src/main/java/com/banklab/stock/dto/StockDTO.java
+++ b/src/main/java/com/banklab/stock/dto/StockDTO.java
@@ -34,6 +34,12 @@ public class StockDTO {
     private String organization;
 
     public StockVO toVO(Long memberId, String connectedId, String organization) {
+        // 종목코드에서 A 접두사 제거 (A005930 -> 005930)
+        String cleanItemCode = resItemCode;
+        if (resItemCode != null && resItemCode.startsWith("A") && resItemCode.length() == 7) {
+            cleanItemCode = resItemCode.substring(1);
+        }
+        
         return StockVO.builder()
                 .memberId(memberId)
                 .connectedId(connectedId)
@@ -44,7 +50,7 @@ public class StockDTO {
                 .resDepositReceivedD2(resDepositReceivedD2)
                 .resProductType(resProductType)
                 .resItemName(resItemName)
-                .resItemCode(resItemCode)
+                .resItemCode(cleanItemCode)  // A 제거된 종목코드 저장
                 .resQuantity(resQuantity)
                 .resPresentAmt(resPresentAmt)
                 .resPurchaseAmount(resPurchaseAmount)

--- a/src/main/java/com/banklab/stock/mapper/StockMapper.java
+++ b/src/main/java/com/banklab/stock/mapper/StockMapper.java
@@ -38,4 +38,14 @@ public interface StockMapper {
     void deleteStocksByConnectedId(@Param("memberId") Long memberId,
                                    @Param("connectedId") String connectedId);
 
+
+    /**
+     * Select : 보유종목 ID와 사용자 ID로 특정 종목 조회 (권한 검증 포함)
+     *
+     * @param stockId 보유종목 ID
+     * @param memberId 서비스 유저 아이디
+     * @return 보유종목 정보 (해당 사용자의 것이 아니면 null)
+     */
+    StockVO getStockByIdAndMemberId(@Param("stockId") Long stockId,
+                                    @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/banklab/stock/service/StockService.java
+++ b/src/main/java/com/banklab/stock/service/StockService.java
@@ -4,6 +4,7 @@ import com.banklab.stock.domain.StockVO;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * 증권 서비스 인터페이스
@@ -43,5 +44,23 @@ public interface StockService {
      * memberId와 connectedId 두 개 모두 일치하는 파라미터가 들어왔을 때 삭제
      */
     void disconnectUserStocks(Long memberId, String connectedId);
+
+    /**
+     * 보유종목 ID로 특정 종목 조회
+     *
+     * @param stockId 보유종목 ID
+     * @param memberId 사용자 ID (권한 검증용)
+     * @return 보유종목 정보
+     */
+    StockVO getStockById(Long stockId, Long memberId);
+
+    /**
+     * 종목코드로 시계열 데이터 조회 (내부 API 호출)
+     *
+     * @param resItemCode 종목코드 (6자리, A 제거된)
+     * @param limit 조회할 개수
+     * @return 시계열 데이터 리스트
+     */
+    List<Map<String, Object>> getTimeSeriesDataByCode(String resItemCode, Integer limit);
 
 }

--- a/src/main/java/com/banklab/stock/service/StockServiceImpl.java
+++ b/src/main/java/com/banklab/stock/service/StockServiceImpl.java
@@ -6,8 +6,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @Log4j2
 @Service
@@ -15,6 +19,8 @@ import java.util.List;
 public class StockServiceImpl implements StockService {
 
     private final StockMapper stockMapper;
+
+    private final RestTemplate restTemplate;
 
     @Override
     @Transactional
@@ -56,4 +62,38 @@ public class StockServiceImpl implements StockService {
         stockMapper.deleteStocksByConnectedId(memberId, connectedId);
     }
 
+
+    @Override
+    public StockVO getStockById(Long stockId, Long memberId) {
+        return stockMapper.getStockByIdAndMemberId(stockId, memberId);
+    }
+
+    @Override
+    public List<Map<String, Object>> getTimeSeriesDataByCode(String resItemCode, Integer limit) {
+        try {
+            // financeContents의 StockController API 호출
+            String url = "http://localhost:8080/api/stocks/timeseries/" + resItemCode + "?limit=" + limit;
+            log.info("시계열 데이터 API 호출: {}", url);
+
+            // RestTemplate으로 내부 API 호출
+            Map<String, Object> response = restTemplate.getForObject(url, Map.class);
+
+            if (response != null && Boolean.TRUE.equals(response.get("success"))) {
+                Object data = response.get("data");
+                if (data instanceof List) {
+                    return (List<Map<String, Object>>) data;
+                }
+            }
+
+            log.warn("시계열 데이터 조회 실패 또는 데이터 없음 - resItemCode: {}", resItemCode);
+            return Collections.emptyList();
+
+        } catch (RestClientException e) {
+            log.error("시계열 데이터 API 호출 실패 - resItemCode: {}, error: {}", resItemCode, e.getMessage());
+            return Collections.emptyList();
+        } catch (Exception e) {
+            log.error("시계열 데이터 조회 중 예상치 못한 오류 - resItemCode: {}", resItemCode, e);
+            return Collections.emptyList();
+        }
+    }
 }

--- a/src/main/resources/com/banklab/stock/mapper/StockMapper.xml
+++ b/src/main/resources/com/banklab/stock/mapper/StockMapper.xml
@@ -145,4 +145,31 @@
           AND connected_id = #{connectedId}
         ORDER BY res_item_name ASC
     </select>
+
+    <select id="getStockByIdAndMemberId" resultMap="stockResultMap">
+        SELECT
+            id,
+            member_id,
+            connected_id,
+            organization,
+            res_account,
+            res_deposit_received,
+            res_deposit_received_d1,
+            res_deposit_received_d2,
+            res_product_type,
+            res_item_name,
+            res_item_code,
+            res_quantity,
+            res_present_amt,
+            res_purchase_amount,
+            res_valuation_amt,
+            res_valuation_pl,
+            res_earnings_rate,
+            res_account_currency,
+            created_at,
+            updated_at
+        FROM stock
+        WHERE id = #{stockId}
+          AND member_id = #{memberId}
+    </select>
 </mapper>


### PR DESCRIPTION
### [BNK-267] Feat : 보유종목 단일항목 보기 API 개발

## 개요

- 단일종목 차트 구현을 위한 단일종목 조회 API 개발
- 
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 코드에 영향 없는 수정
- [ ] 문서 수정
- [ ] 테스트 추가/리팩토링
- [ ] 빌드/패키지 관련
- [ ] 파일/폴더명 수정
- [ ] 파일 삭제

## PR Checklist

- [x] 1. 커밋 메시지 컨벤션을 지켰나요?
- [x] 2. 기능 테스트를 완료했나요?
- [ ] 3-1. main 브랜치로 머지 요청했나요?
- [x] 3-2. develop 브랜치로 머지 요청했나요?

## 테스트 결과 (캡쳐이미지)
<img width="1392" height="1014" alt="image" src="https://github.com/user-attachments/assets/3d5bbf8c-e137-41a9-945a-83e012eda802" />


[BNK-267]: https://banklab00.atlassian.net/browse/BNK-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ