### PR TITLE
[BNK-291] Fix :주식 데이터 불러오기 post 요청 번거러움 -> Runner 개발

### DIFF
--- a/src/main/java/com/banklab/financeContents/util/StockDataUpdateRunner.java
+++ b/src/main/java/com/banklab/financeContents/util/StockDataUpdateRunner.java
@@ -1,0 +1,92 @@
+package com.banklab.financeContents.util;
+
+import com.banklab.financeContents.service.FinanceStockService;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.web.client.RestTemplate;
+
+import javax.sql.DataSource;
+
+/**
+ * 주식 데이터 업데이트 러너
+ * POST /api/stocks/save/recent 와 동일한 기능을 수행
+ */
+@Slf4j
+public class StockDataUpdateRunner {
+
+    public static void main(String[] args) {
+        log.info("🚀 주식 데이터 업데이트 시작");
+        
+        try {
+            // 최소한의 Spring 컨텍스트 로드 (Security 제외)
+            ApplicationContext context = new AnnotationConfigApplicationContext(MinimalConfig.class);
+            FinanceStockService financeStockService = context.getBean(FinanceStockService.class);
+            
+            // 1. 오래된 데이터 삭제
+            log.info("🗑️ 30일 이전 데이터 삭제 중...");
+            int deletedCount = financeStockService.deleteOldData();
+            log.info("✅ 삭제 완료: {}건", deletedCount);
+            
+            // 2. 최근 30일간 상위 200개 종목 데이터 저장
+            log.info("📊 최근 30일간 데이터 저장 중...");
+            int savedCount = financeStockService.saveRecentStockData(30, 1000);
+            log.info("✅ 저장 완료: {}건", savedCount);
+            
+            log.info("🎉 업데이트 완료! 삭제: {}건, 저장: {}건", deletedCount, savedCount);
+            
+        } catch (Exception e) {
+            log.error("❌ 업데이트 실패: {}", e.getMessage(), e);
+            System.exit(1);
+        }
+    }
+
+    /**
+     * 러너 전용 최소 설정 클래스 (Security 제외)
+     */
+    @Configuration
+    @MapperScan(basePackages = "com.banklab.financeContents.mapper")
+    @ComponentScan(basePackages = "com.banklab.financeContents.service")
+    @EnableTransactionManagement
+    static class MinimalConfig {
+
+        @Bean
+        public DataSource dataSource() {
+            HikariConfig config = new HikariConfig();
+            config.setDriverClassName("net.sf.log4jdbc.sql.jdbcapi.DriverSpy");
+            config.setJdbcUrl("jdbc:log4jdbc:mysql://localhost:3306/banklab");
+            config.setUsername("root");
+            config.setPassword("1234");
+            return new HikariDataSource(config);
+        }
+
+        @Bean
+        public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
+            SqlSessionFactoryBean factory = new SqlSessionFactoryBean();
+            factory.setDataSource(dataSource);
+            factory.setConfigLocation(new ClassPathResource("mybatis-config.xml"));
+            return factory.getObject();
+        }
+
+        @Bean
+        public DataSourceTransactionManager transactionManager(DataSource dataSource) {
+            return new DataSourceTransactionManager(dataSource);
+        }
+
+        @Bean
+        public RestTemplate restTemplate() {
+            return new RestTemplate();
+        }
+    }
+}


### PR DESCRIPTION
### [BNK-291] Fix :주식 데이터 불러오기 post 요청 번거러움 -> Runner 개발

## 개요

- 주식 데이터 30일치 불러오는 과정에서 post 요청으로 talend, postman으로 요청하는 번거로운 과정 확인
- Runner 실행으로 소스 코드에서 바로 할 수 있도록 적용
- Runner 개발 완료

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [x] 코드에 영향 없는 수정
- [ ] 문서 수정
- [ ] 테스트 추가/리팩토링
- [ ] 빌드/패키지 관련
- [ ] 파일/폴더명 수정
- [ ] 파일 삭제

## PR Checklist

- [x] 1. 커밋 메시지 컨벤션을 지켰나요?
- [x] 2. 기능 테스트를 완료했나요?
- [ ] 3-1. main 브랜치로 머지 요청했나요?
- [x] 3-2. develop 브랜치로 머지 요청했나요?

## 테스트 결과 (캡쳐이미지)


[BNK-291]: https://banklab00.atlassian.net/browse/BNK-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ